### PR TITLE
Allow insecured for HTTPS connections, for cases behind corporate proxy

### DIFF
--- a/oterm/config.py
+++ b/oterm/config.py
@@ -24,6 +24,7 @@ class AppConfig:
 
     ENV: str = "development"
     OLLAMA_URL: str = "http://localhost:11434/api"
+    OLLAMA_VERIFY: bool = True
 
     def __init__(self, env):
         for field in self.__annotations__:

--- a/oterm/ollama.py
+++ b/oterm/ollama.py
@@ -52,7 +52,7 @@ class OllamaLLM:
         prompt: str,
         context: list[int],
     ) -> AsyncGenerator[tuple[str, list[int]], Any]:
-        client = httpx.AsyncClient()
+        client = httpx.AsyncClient(verify=Config.OLLAMA_VERIFY)
         jsn = {
             "model": self.model,
             "prompt": prompt,
@@ -80,12 +80,12 @@ class OllamaLLM:
 
 class OllamaAPI:
     async def get_models(self) -> list[dict[str, Any]]:
-        client = httpx.AsyncClient()
+        client = httpx.AsyncClient(verify=Config.OLLAMA_VERIFY)
         response = await client.get(f"{Config.OLLAMA_URL}/tags")
         return response.json().get("models", []) or []
 
     async def get_model_info(self, model: str) -> dict[str, Any]:
-        client = httpx.AsyncClient()
+        client = httpx.AsyncClient(verify=Config.OLLAMA_VERIFY)
         response = await client.post(f"{Config.OLLAMA_URL}/show", json={"name": model})
         if response.json().get("error"):
             raise OllamaError(response.json()["error"])


### PR DESCRIPTION
added env var to allow the insecured traffic through https connections. Default should work as normal. But with the flag enabled, users can connect to ollama insecurely.