### PR TITLE
Support OLLAMA_URL and OLLAMA_HOST

### DIFF
--- a/oterm/config.py
+++ b/oterm/config.py
@@ -58,7 +58,7 @@ class AppConfig:
                     )
                 )
         if self.OLLAMA_URL == "":
-            self.OLLAMA_URL = f"http://{self.OLLAMA_HOST}"
+            self.OLLAMA_URL = f"http://{self.OLLAMA_HOST}/api"
 
     def __repr__(self):
         return str(self.__dict__)

--- a/oterm/ollama.py
+++ b/oterm/ollama.py
@@ -82,7 +82,7 @@ class OllamaLLM:
 
         try:
             async with client.stream(
-                "POST", f"{Config.OLLAMA_URL}/api/generate", json=jsn, timeout=None
+                "POST", f"{Config.OLLAMA_URL}/generate", json=jsn, timeout=None
             ) as response:
                 async for line in response.aiter_lines():
                     body = json.loads(line)
@@ -101,7 +101,7 @@ class OllamaAPI:
     async def get_models(self) -> list[dict[str, Any]]:
         client = httpx.AsyncClient(verify=Config.OTERM_VERIFY_SSL)
         try:
-            response = await client.get(f"{Config.OLLAMA_URL}/api/tags")
+            response = await client.get(f"{Config.OLLAMA_URL}/tags")
         except httpx.ConnectError:
             raise OllamaConnectError()
         return response.json().get("models", []) or []
@@ -110,7 +110,7 @@ class OllamaAPI:
         client = httpx.AsyncClient(verify=Config.OTERM_VERIFY_SSL)
         try:
             response = await client.post(
-                f"{Config.OLLAMA_URL}/api/show", json={"name": model}
+                f"{Config.OLLAMA_URL}/show", json={"name": model}
             )
         except httpx.ConnectError:
             raise OllamaConnectError()
@@ -121,7 +121,7 @@ class OllamaAPI:
     async def pull_model(self, model: str) -> None:
         client = httpx.AsyncClient()
         async with client.stream(
-            "POST", f"{Config.OLLAMA_URL}/api/pull", json={"name": model}, timeout=None
+            "POST", f"{Config.OLLAMA_URL}/pull", json={"name": model}, timeout=None
         ) as response:
             async for line in response.aiter_lines():
                 body = json.loads(line)


### PR DESCRIPTION
Restores the original behavior of OLLAMA_URL,
which requires that the full path be specified,
including the /api prefix. Also supports the
OLLAMA_HOST behavior requested in
resolved ggozad/oterm#37 by adding the /api
prefix when constructing the OLLAMA_URL.