### PR TITLE
Support passing data dir via env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 dist/
 oterm.rb
 photos/
+.vscode

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.2.4 - 2024-02-29
+------------------
+
+- Allow user to customize the path of data dir via the OTERM_DATA_DIR env.
+  [PeronGH]
+
 0.2.3 - 2024-02-28
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # oterm
+
 the text-based terminal client for [Ollama](https://github.com/jmorganca/ollama).
 
 ## Features
@@ -57,10 +58,12 @@ You can also "edit" the chat to change the template, system prompt or format. No
 
 ### Chat session storage
 
-All your chat sessions are stored locally in a sqlite database.
+All your chat sessions are stored locally in a sqlite database. You can customize the directory where the database is stored by setting the `OTERM_DATA_DIR` environment variable.
+
 You can find the location of the database by running `oterm --db`.
 
 ### Screenshots
+
 ![Chat](screenshots/chat.png)
 ![Model selection](./screenshots/model_selection.png)
 ![Image selection](./screenshots/image_selection.png)

--- a/oterm/cli/oterm.py
+++ b/oterm/cli/oterm.py
@@ -5,7 +5,7 @@ import typer
 
 from oterm.app.oterm import app
 from oterm.store.store import Store
-from oterm.utils import get_data_dir
+from oterm.config import envConfig
 
 cli = typer.Typer()
 
@@ -27,7 +27,7 @@ def oterm(
         asyncio.run(upgrade_db())
         exit(0)
     if sqlite:
-        typer.echo(get_data_dir() / "store.db")
+        typer.echo(envConfig.OTERM_DATA_DIR / "store.db")
         exit(0)
     app.run()
 

--- a/oterm/config.py
+++ b/oterm/config.py
@@ -5,7 +5,8 @@ from typing import Union, get_type_hints
 
 from dotenv import load_dotenv
 
-from oterm.utils import get_data_dir
+from oterm.utils import get_default_data_dir
+
 
 load_dotenv()
 
@@ -29,6 +30,7 @@ class EnvConfig:
     OLLAMA_HOST: str = "0.0.0.0:11434"
     OLLAMA_URL: str = ""
     OTERM_VERIFY_SSL: bool = True
+    OTERM_DATA_DIR: Path = get_default_data_dir()
 
     def __init__(self, env):
         for field in self.__annotations__:
@@ -67,10 +69,14 @@ class EnvConfig:
         return str(self.__dict__)
 
 
+# Expose EnvConfig object for app to import
+envConfig = EnvConfig(os.environ)
+
+
 class AppConfig:
     def __init__(self, path: Path = None):
         if path is None:
-            path = get_data_dir() / "config.json"
+            path = envConfig.OTERM_DATA_DIR / "config.json"
         self._path = path
         self._data = {
             "theme": "dark",
@@ -95,6 +101,5 @@ class AppConfig:
             json.dump(self._data, f)
 
 
-# Expose Config object for app to import
-envConfig = EnvConfig(os.environ)
+# Expose AppConfig object for app to import
 appConfig = AppConfig()

--- a/oterm/store/store.py
+++ b/oterm/store/store.py
@@ -10,7 +10,11 @@ from oterm.app.widgets.chat import Author
 from oterm.store.chat import queries as chat_queries
 from oterm.store.setup import queries as setup_queries
 from oterm.store.upgrades import upgrades
-from oterm.utils import get_data_dir, int_to_semantic_version, semantic_version_to_int
+from oterm.utils import (
+    int_to_semantic_version,
+    semantic_version_to_int,
+)
+from oterm.config import envConfig
 
 
 class Store(object):
@@ -19,7 +23,7 @@ class Store(object):
     @classmethod
     async def create(cls) -> "Store":
         self = Store()
-        data_path = get_data_dir()
+        data_path = envConfig.OTERM_DATA_DIR
         data_path.mkdir(parents=True, exist_ok=True)
         self.db_path = data_path / "store.db"
 

--- a/oterm/utils.py
+++ b/oterm/utils.py
@@ -3,11 +3,10 @@ from pathlib import Path
 import os
 
 
-def get_data_dir() -> Path:
+def get_default_data_dir() -> Path:
     """
     Get the user data directory for the current system platform.
 
-    First checks the OTERM_DATA_DIR environment variable. If not set, defaults to:
     Linux: ~/.local/share/oterm
     macOS: ~/Library/Application Support/oterm
     Windows: C:/Users/<USER>/AppData/Roaming/oterm
@@ -15,10 +14,6 @@ def get_data_dir() -> Path:
     :return: User Data Path
     :rtype: Path
     """
-    oterm_data_dir = os.environ.get("OTERM_DATA_DIR")
-    if oterm_data_dir:
-        return Path(oterm_data_dir)
-
     home = Path.home()
 
     system_paths = {

--- a/oterm/utils.py
+++ b/oterm/utils.py
@@ -1,18 +1,24 @@
 import sys
 from pathlib import Path
+import os
 
 
 def get_data_dir() -> Path:
     """
     Get the user data directory for the current system platform.
 
+    First checks the OTERM_DATA_DIR environment variable. If not set, defaults to:
     Linux: ~/.local/share/oterm
     macOS: ~/Library/Application Support/oterm
     Windows: C:/Users/<USER>/AppData/Roaming/oterm
 
     :return: User Data Path
-    :rtype: str
+    :rtype: Path
     """
+    oterm_data_dir = os.environ.get("OTERM_DATA_DIR")
+    if oterm_data_dir:
+        return Path(oterm_data_dir)
+
     home = Path.home()
 
     system_paths = {


### PR DESCRIPTION
This PR allows the user to customize the path of data dir via the `OTERM_DATA_DIR` env.