### PR TITLE
Monkey patch MarkdownFence to capture click.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.2.5 - 
+------------------
+
+- Monkey patch MarkdownFence to capture click.
+  [ggozad]
+
 0.2.4 - 2024-03-19
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ While Ollama is inferring the next message, you can press <kbd>Esc</kbd> to canc
 
 Note that some of the shortcuts may not work in a certain context, for example pressing <kbd>↑</kbd> while the prompt is in multi-line mode.
 
+### Copy / Paste
+
+It is difficult to properly support copy/paste in terminal applications. You can copy blocks to your clipboard as such:
+
+* clicking a message will copy it to the clipboard.
+* clicking a code block will only copy the code block to the clipboard.
+
+For most terminals there exists a key modifier you can use to click and drag to manually select text. For example:
+* `iTerm`  <kbd>Option</kbd> key.
+* `Gnome Terminal` <kbd>Shift</kbd> key.
+* `Windows Terminal` <kbd>Shift</kbd> key.
+
+
 ### Customizing models
 
 When creating a new chat, you may not only select the model, but also customize the `template` as well as the `system` instruction to pass to the model. Checking the `JSON output` checkbox will cause the model reply in JSON format. Please note that `oterm` will not (yet) pull models for you, use `ollama` to do that. All the models you have pulled or created will be available to `oterm`.

--- a/oterm/app/widgets/__init__.py
+++ b/oterm/app/widgets/__init__.py
@@ -1,0 +1,1 @@
+import oterm.app.widgets.monkey  # noqa: F401

--- a/oterm/app/widgets/monkey.py
+++ b/oterm/app/widgets/monkey.py
@@ -1,0 +1,21 @@
+import pyperclip
+import textual.widgets._markdown as markdown
+from textual import on
+from textual.events import Click
+
+
+class MarkdownFence(markdown.MarkdownFence):
+    @on(Click)
+    async def on_click(self, event: Click) -> None:
+        event.stop()
+        try:
+            pyperclip.copy(self.code)
+        except pyperclip.PyperclipException:
+            # https://pyperclip.readthedocs.io/en/latest/index.html#not-implemented-error
+            return
+
+        self.styles.animate("opacity", 0.5, duration=0.1)
+        self.styles.animate("opacity", 1.0, duration=0.1, delay=0.1)
+
+
+markdown.MarkdownFence = MarkdownFence


### PR DESCRIPTION
Allows to support copy to clipboard in markdown code blocks.