### PR TITLE
Use correct ollama client in ChatEdit screen. Fix #76

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.2.7 - 2024-04-22
+------------------
+
+- Fixed a bug that ChatEdit screen did not use environment variables to request ollama.
+  [habaneraa]
+
 0.2.6 - 2024-04-20
 ------------------
 

--- a/oterm/app/chat_edit.py
+++ b/oterm/app/chat_edit.py
@@ -2,7 +2,6 @@ import json
 from ast import literal_eval
 from typing import Any
 
-import ollama
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
@@ -12,6 +11,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Label, OptionList, Pretty
 
 from oterm.app.widgets.text_area import TextArea
+from oterm.ollama import ollama_client
 
 
 class ChatEdit(ModalScreen[str]):
@@ -74,10 +74,10 @@ class ChatEdit(ModalScreen[str]):
                 break
 
     async def on_mount(self) -> None:
-        self.models = ollama.list()["models"]
+        self.models = (await ollama_client.list())["models"]
         models = [model["name"] for model in self.models]
         for model in models:
-            info = dict(ollama.show(model))
+            info = dict(await ollama_client.show(model))
             for key in ["modelfile", "license"]:
                 if key in info.keys():
                     del info[key]

--- a/oterm/app/chat_edit.py
+++ b/oterm/app/chat_edit.py
@@ -11,7 +11,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Label, OptionList, Pretty
 
 from oterm.app.widgets.text_area import TextArea
-from oterm.ollama import ollama_client
+from oterm.ollama import OllamaLLM
 
 
 class ChatEdit(ModalScreen[str]):
@@ -74,10 +74,10 @@ class ChatEdit(ModalScreen[str]):
                 break
 
     async def on_mount(self) -> None:
-        self.models = (await ollama_client.list())["models"]
+        self.models = OllamaLLM.list()["models"]
         models = [model["name"] for model in self.models]
         for model in models:
-            info = dict(await ollama_client.show(model))
+            info = dict(OllamaLLM.show(model))
             for key in ["modelfile", "license"]:
                 if key in info.keys():
                     del info[key]

--- a/oterm/ollama.py
+++ b/oterm/ollama.py
@@ -4,6 +4,8 @@ from ollama import AsyncClient
 
 from oterm.config import envConfig
 
+ollama_client = AsyncClient(host=envConfig.OLLAMA_URL, verify=envConfig.OTERM_VERIFY_SSL)
+
 
 class OllamaLLM:
     def __init__(

--- a/oterm/ollama.py
+++ b/oterm/ollama.py
@@ -1,10 +1,8 @@
-from typing import Any, AsyncGenerator, AsyncIterator, Literal
+from typing import Any, AsyncGenerator, AsyncIterator, Literal, Mapping
 
-from ollama import AsyncClient
+from ollama import AsyncClient, Client
 
 from oterm.config import envConfig
-
-ollama_client = AsyncClient(host=envConfig.OLLAMA_URL, verify=envConfig.OTERM_VERIFY_SSL)
 
 
 class OllamaLLM:
@@ -56,3 +54,17 @@ class OllamaLLM:
             if "context" in response:
                 self.context = response.get("context")
             yield text
+
+    @staticmethod
+    def list() -> Mapping[str, Any]:
+        client = Client(
+            host=envConfig.OLLAMA_URL, verify=envConfig.OTERM_VERIFY_SSL
+        )
+        return client.list()
+
+    @staticmethod
+    def show(model: str) -> Mapping[str, Any]:
+        client = Client(
+            host=envConfig.OLLAMA_URL, verify=envConfig.OTERM_VERIFY_SSL
+        )
+        return client.show(model)


### PR DESCRIPTION
A simple fix for issue #76 .

In addition, I think maybe we can extract these local variables to a global `client` variable, which naturally functions as a singleton object.

https://github.com/ggozad/oterm/blob/147cd2fa23d2cbcf725d565244ae25bd2f10d135/oterm/ollama.py#L22-L24

https://github.com/ggozad/oterm/blob/147cd2fa23d2cbcf725d565244ae25bd2f10d135/oterm/ollama.py#L39-L41
