### PR TITLE
Cycle saved chats with Ctrl+Tab

### DIFF
--- a/oterm/app/oterm.py
+++ b/oterm/app/oterm.py
@@ -17,6 +17,8 @@ class OTerm(App):
     CSS_PATH = "oterm.tcss"
     BINDINGS = [
         ("ctrl+n", "new_chat", "new"),
+        ("ctrl+tab", "next_chat", "next chat"),
+        ("ctrl+shift+tab", "prev_chat", "prev chat"),
         ("ctrl+t", "toggle_dark", "toggle theme"),
         ("ctrl+q", "quit", "quit"),
     ]
@@ -27,6 +29,32 @@ class OTerm(App):
 
     async def action_quit(self) -> None:
         return self.exit()
+
+    async def action_next_chat(self) -> None:
+        tabs = self.query_one(TabbedContent)
+        saved_chats = await self.store.get_chats()
+        if tabs.active_pane is None:
+            return
+        active_id = int(str(tabs.active_pane.id).split("-")[1])
+        for _chat in saved_chats:
+            if _chat[0] == active_id:
+                next_index = (saved_chats.index(_chat) + 1) % len(saved_chats)
+                next_id = saved_chats[next_index][0]
+                tabs.active = f"chat-{next_id}"
+                break
+        
+    async def action_prev_chat(self) -> None:
+        tabs = self.query_one(TabbedContent)
+        saved_chats = await self.store.get_chats()
+        if tabs.active_pane is None:
+            return
+        active_id = int(str(tabs.active_pane.id).split("-")[1])
+        for _chat in saved_chats:
+            if _chat[0] == active_id:
+                prev_index = (saved_chats.index(_chat) - 1) % len(saved_chats)
+                prev_id = saved_chats[prev_index][0]
+                tabs.active = f"chat-{prev_id}"
+                break
 
     def action_new_chat(self) -> None:
         async def on_model_select(model_info: str | None) -> None:


### PR DESCRIPTION
While using the tool (which is amazing btw), I would try using Ctrl+Tab and Ctrl+Shift+Tab like in the browser. So, I thought it would be useful for other people too.

Ctrl+Tab cycles saved chats from left to right
Ctrl+Shift+Tab cycles saved chats from right to left

PR adds:
```
action_next_chat()
action_prev_chat()

BINDINGS:
ctrl+tab -> next chat -> action_next_chat
ctrl+shirt+tab -> prev chat -> action_prev_chat
```