### PR TITLE
Support for command palette instead of shortcuts.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.5.0 -
+------------------
+
+- Add support for the command palette. Move most chat-related actions there.
+  [ggozad]
+
 0.4.4 - 2024-08-30
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -38,18 +38,30 @@ In order to use `oterm` you will need to have the Ollama server running. By defa
 OLLAMA_URL=http://host:port/api
 ```
 
+To start `oterm` simply run:
+
+```bash
+oterm
+```
+
+### Commands
+By pressing <kbd>^ Ctrl</kbd>+<kbd>p</kbd> you can access the command palette from where you can perform most of the chat management. The following commands are available:
+
+* `New chat` - create a new chat session
+* `Edit chat parameters` - edit the current chat session (change system prompt, parameters or format)
+* `Rename chat` - rename the current chat session
+* `Export chat` - export the current chat session as markdown
+* `Delete chat` - delete the current chat session  
+
+### Keyboard shortcuts
+
 The following keyboard shortcuts are supported:
 
-* <kbd>^ Ctrl</kbd>+<kbd>N</kbd> - create a new chat session
-* <kbd>^ Ctrl</kbd>+<kbd>E</kbd> - edit the chat session (change template, system prompt or format)
-* <kbd>^ Ctrl</kbd>+<kbd>R</kbd> - rename the current chat session
-* <kbd>^ Ctrl</kbd>+<kbd>S</kbd> - export the current chat session as markdown
-* <kbd>^ Ctrl</kbd>+<kbd>X</kbd> - delete the current chat session
-* <kbd>^ Ctrl</kbd>+<kbd>T</kbd> - toggle between dark/light theme
-* <kbd>^ Ctrl</kbd>+<kbd>Q</kbd> - quit
+* <kbd>^ Ctrl</kbd>+<kbd>t</kbd> - toggle between dark/light theme
+* <kbd>^ Ctrl</kbd>+<kbd>q</kbd> - quit
 
-* <kbd>^ Ctrl</kbd>+<kbd>L</kbd> - switch to multiline input mode
-* <kbd>^ Ctrl</kbd>+<kbd>P</kbd> - select an image to include with the next message
+* <kbd>^ Ctrl</kbd>+<kbd>l</kbd> - switch to multiline input mode
+* <kbd>^ Ctrl</kbd>+<kbd>i</kbd> - select an image to include with the next message
 * <kbd>↑</kbd>     - navigate through history of previous prompts
 
 * <kbd>^ Ctrl</kbd>+<kbd>Tab</kbd> - open the next chat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "textual>=0.76.0",
+    "textual>=0.78.0",
     "typer>=0.12.4",
     "python-dotenv>=1.0.1",
     "aiosql>=11.1",

--- a/src/oterm/app/chat_rename.py
+++ b/src/oterm/app/chat_rename.py
@@ -7,9 +7,14 @@ from textual.widgets import Input, Label
 
 class ChatRename(ModalScreen[str]):
     old_name: str = ""
+
     BINDINGS = [
         ("escape", "cancel", "Cancel"),
     ]
+
+    def __init__(self, old_name: str) -> None:
+        super().__init__()
+        self.old_name = old_name
 
     def action_cancel(self) -> None:
         self.dismiss()

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -34,6 +34,9 @@ class OTerm(App):
         yield SystemCommand(
             "Rename chat", "Renames the current chat.", self.action_rename_chat
         )
+        yield SystemCommand(
+            "Delete chat", "Deletes the current chat.", self.action_delete_chat
+        )
 
     async def action_quit(self) -> None:
         return self.exit()
@@ -100,6 +103,15 @@ class OTerm(App):
             return
         chat = tabs.active_pane.query_one(ChatContainer)
         chat.action_rename_chat()
+
+    async def action_delete_chat(self) -> None:
+        tabs = self.query_one(TabbedContent)
+        if tabs.active_pane is None:
+            return
+        chat = tabs.active_pane.query_one(ChatContainer)
+        store = await Store.get_store()
+        await store.delete_chat(chat.db_id)
+        await tabs.remove_pane(tabs.active)
 
     async def on_mount(self) -> None:
         store = await Store.get_store()

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -25,7 +25,12 @@ class OTerm(App):
 
     def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
         yield from super().get_system_commands(screen)
-        yield SystemCommand("New chat", "Creates a new chat", self.action_new_chat)
+        yield SystemCommand("New chat", "Creates a new chat.", self.action_new_chat)
+        yield SystemCommand(
+            "Edit chat parameters",
+            "Allows to redefine model parameters and system prompt.",
+            self.action_edit_chat,
+        )
 
     async def action_quit(self) -> None:
         return self.exit()
@@ -46,7 +51,6 @@ class OTerm(App):
 
     @work
     async def action_new_chat(self) -> None:
-
         store = await Store.get_store()
         model_info: str | None = await self.push_screen_wait(ChatEdit())
         if not model_info:
@@ -79,6 +83,13 @@ class OTerm(App):
         )
         await tabs.add_pane(pane)
         tabs.active = f"chat-{id}"
+
+    async def action_edit_chat(self) -> None:
+        tabs = self.query_one(TabbedContent)
+        if tabs.active_pane is None:
+            return
+        chat = tabs.active_pane.query_one(ChatContainer)
+        chat.action_edit_chat()
 
     async def on_mount(self) -> None:
         store = await Store.get_store()

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -31,6 +31,9 @@ class OTerm(App):
             "Allows to redefine model parameters and system prompt.",
             self.action_edit_chat,
         )
+        yield SystemCommand(
+            "Rename chat", "Renames the current chat.", self.action_rename_chat
+        )
 
     async def action_quit(self) -> None:
         return self.exit()
@@ -90,6 +93,13 @@ class OTerm(App):
             return
         chat = tabs.active_pane.query_one(ChatContainer)
         chat.action_edit_chat()
+
+    async def action_rename_chat(self) -> None:
+        tabs = self.query_one(TabbedContent)
+        if tabs.active_pane is None:
+            return
+        chat = tabs.active_pane.query_one(ChatContainer)
+        chat.action_rename_chat()
 
     async def on_mount(self) -> None:
         store = await Store.get_store()

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -1,7 +1,9 @@
 import json
+from typing import Iterable
 
 from textual import on
-from textual.app import App, ComposeResult
+from textual.app import App, ComposeResult, SystemCommand
+from textual.screen import Screen
 from textual.widgets import Footer, Header, TabbedContent, TabPane
 
 from oterm.app.chat_edit import ChatEdit
@@ -23,6 +25,9 @@ class OTerm(App):
         ("ctrl+q", "quit", "quit"),
     ]
     COMMAND_PALETTE_BINDING = "ctrl+backslash"
+
+    def get_system_commands(self, screen: Screen) -> Iterable[SystemCommand]:
+        yield from super().get_system_commands(screen)
 
     def action_toggle_dark(self) -> None:
         self.dark = not self.dark

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -42,8 +42,6 @@ class ChatContainer(Widget):
 
     BINDINGS = [
         Binding("ctrl+s", "export", "export", priority=True),
-        ("ctrl+r", "rename_chat", "rename"),
-        ("ctrl+x", "forget_chat", "forget"),
         Binding("up", "history", "history"),
         Binding(
             "escape", "cancel_inference", "cancel inference", show=False, priority=True
@@ -236,12 +234,6 @@ class ChatContainer(Widget):
         tabs = self.app.query_one(TabbedContent)
         await store.rename_chat(self.db_id, new_name)
         tabs.get_tab(f"chat-{self.db_id}").update(new_name)
-
-    async def action_forget_chat(self) -> None:
-        tabs = self.app.query_one(TabbedContent)
-        store = await Store.get_store()
-        await store.delete_chat(self.db_id)
-        tabs.remove_pane(tabs.active)
 
     async def action_history(self) -> None:
         def on_history_selected(text: str | None) -> None:

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -225,18 +225,17 @@ class ChatContainer(Widget):
         screen.file_name = f"{slugify(self.chat_name)}.md"
         self.app.push_screen(screen)
 
+    @work
     async def action_rename_chat(self) -> None:
-        async def on_chat_rename(name: str | None) -> None:
-            store = await Store.get_store()
-            if name is None:
-                return
-            tabs = self.app.query_one(TabbedContent)
-            await store.rename_chat(self.db_id, name)
-            tabs.get_tab(f"chat-{self.db_id}").update(name)
+        store = await Store.get_store()
 
-        screen = ChatRename()
-        screen.old_name = self.chat_name
-        self.app.push_screen(screen, on_chat_rename)
+        screen = ChatRename(self.chat_name)
+        new_name = await self.app.push_screen_wait(screen)
+        if new_name is None:
+            return
+        tabs = self.app.query_one(TabbedContent)
+        await store.rename_chat(self.db_id, new_name)
+        tabs.get_tab(f"chat-{self.db_id}").update(new_name)
 
     async def action_forget_chat(self) -> None:
         tabs = self.app.query_one(TabbedContent)

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -20,7 +20,6 @@ from textual.widgets import (
 )
 
 from oterm.app.chat_edit import ChatEdit
-from oterm.app.chat_export import ChatExport, slugify
 from oterm.app.chat_rename import ChatRename
 from oterm.app.prompt_history import PromptHistory
 from oterm.app.widgets.image import ImageAdded
@@ -41,7 +40,6 @@ class ChatContainer(Widget):
     images: list[tuple[Path, str]] = []
 
     BINDINGS = [
-        Binding("ctrl+s", "export", "export", priority=True),
         Binding("up", "history", "history"),
         Binding(
             "escape", "cancel_inference", "cancel inference", show=False, priority=True
@@ -216,12 +214,6 @@ class ChatContainer(Widget):
             keep_alive=model["keep_alive"],
             history=history,
         )
-
-    async def action_export(self) -> None:
-        screen = ChatExport()
-        screen.chat_id = self.db_id
-        screen.file_name = f"{slugify(self.chat_name)}.md"
-        self.app.push_screen(screen)
 
     @work
     async def action_rename_chat(self) -> None:

--- a/src/oterm/app/widgets/prompt.py
+++ b/src/oterm/app/widgets/prompt.py
@@ -90,7 +90,7 @@ class FlexibleInput(Widget):
     text = reactive("")
 
     BINDINGS = [
-        ("ctrl+p", "add_image", "add image"),
+        ("ctrl+i", "add_image", "add image"),
     ]
 
     @dataclass

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "oterm"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosql" },
@@ -575,7 +575,7 @@ requires-dist = [
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rich-pixels", specifier = ">=3.0.1" },
-    { name = "textual", specifier = ">=0.76.0" },
+    { name = "textual", specifier = ">=0.78.0" },
     { name = "typer", specifier = ">=0.12.4" },
 ]
 
@@ -825,16 +825,16 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "0.76.0"
+version = "0.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify", "plugins"] },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/ea/9139a6156c6dc2f40592fc50dceb8c57c5e53d235c20c2c41fe3cc363b1f/textual-0.76.0.tar.gz", hash = "sha256:b12e8879d591090c0901b5cb8121d086e28e677353b368292d3865ec99b83b70", size = 1325760 }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/65/0feb87888b582d4d6cd8ab5cf23f36e711894db33d91a4282311c05fc870/textual-0.78.0.tar.gz", hash = "sha256:421f508b0d41ea0b8ecf273bf83f0d19376667eb0a87f70575252395d90ab315", size = 1354115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/54/fe61cbc119cd8df62c7c37204b88ec2c3c260ebd41f73167ea6fbae1f592/textual-0.76.0-py3-none-any.whl", hash = "sha256:e2035609c889dba507d34a5d7b333f1c8c53a29fb170962cb92101507663517a", size = 567244 },
+    { url = "https://files.pythonhosted.org/packages/69/68/0b99efe3f61d0b65de3b1f0db6889c2386db88a4d6b8ca2ed2adc5982f77/textual-0.78.0-py3-none-any.whl", hash = "sha256:c9d3c7dc467c37ee2e54a0283ac2c85dac35e4fc949518ed054a65b8e3e9b822", size = 574745 },
 ]
 
 [[package]]


### PR DESCRIPTION
We move most of the chat-related actions such as new, edit, export etc. to the command palette built into `textual`.
This makes it easier to navigate actions and clears up some space for shortcuts. 