### PR TITLE
Import additional tools from the otermtools namespace

### DIFF
--- a/src/oterm/tools/__init__.py
+++ b/src/oterm/tools/__init__.py
@@ -1,5 +1,8 @@
+import importlib
+import pkgutil
 from typing import Awaitable, Callable, Sequence, TypedDict
 
+from attr import has
 from ollama._types import (
     Parameters,
     Property,
@@ -26,3 +29,17 @@ available: Sequence[ToolDefinition] = [
     {"tool": LocationTool, "callable": current_location},
     {"tool": WeatherTool, "callable": current_weather},
 ]
+
+try:
+    import otermtools  # type: ignore  # noqa: I001
+
+    # otermtools is a namespace, let's discover all the modules and tools in it.
+    modules = pkgutil.iter_modules(otermtools.__path__)
+    for module in modules:
+        module_name = f"otermtools.{module.name}"
+        module = importlib.import_module(module_name)
+        if hasattr(module, "tools"):
+            for tool in module.tools:
+                available.append(tool)
+except ImportError:
+    pass


### PR DESCRIPTION
`otermtools` will be used as a package namespace for packages providing extra functionality as tools to `oterm`.
This is under development, the first candidate being https://github.com/ggozad/otermtools.rag