### PR TITLE
Remove the erroneous comma from the keymap example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ We strive to have sane default key bindings, but there will always be cases wher
     "next.chat": "ctrl+tab",
     "prev.chat": "ctrl+shift+tab",
     "quit": "ctrl+q",
-    "newline": "shift+enter",
+    "newline": "shift+enter"
   }
 }
 ```


### PR DESCRIPTION
The keymap example does not work, because the JSONDecoder does not like the comma in the last line. I removed it