### PR TITLE
add back binding for new_chat and delete chat

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.6.10 - 2024-12-27
+-------------------
+
+- Update the shortcuts for new chat and close chat.
+  [pekcheey]
+
+
 0.6.9 - 2024-11-23
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ The following keyboard shortcuts are supported:
 * <kbd>^ Ctrl</kbd>+<kbd>i</kbd> - select an image to include with the next message
 * <kbd>↑</kbd>     - navigate through history of previous prompts
 
+* <kbd>^ Ctrl</kbd>+<kbd>n</kbd> - open a new chat
+* <kbd>^ Ctrl</kbd>+<kbd>Backspace</kbd> - close the current chat
+
 * <kbd>^ Ctrl</kbd>+<kbd>Tab</kbd> - open the next chat
 * <kbd>^ Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> - open the previous chat
 

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -23,6 +23,8 @@ class OTerm(App):
     BINDINGS = [
         Binding("ctrl+tab", "cycle_chat(+1)", "next chat", id="next.chat"),
         Binding("ctrl+shift+tab", "cycle_chat(-1)", "prev chat", id="prev.chat"),
+        Binding("ctrl+x", "delete_chat", "delete chat", id="delete.chat"),
+        Binding("ctrl+n", "new_chat", "new chat", id="new.chat"),
         Binding("ctrl+q", "quit", "quit", id="quit"),
     ]
 

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -23,7 +23,7 @@ class OTerm(App):
     BINDINGS = [
         Binding("ctrl+tab", "cycle_chat(+1)", "next chat", id="next.chat"),
         Binding("ctrl+shift+tab", "cycle_chat(-1)", "prev chat", id="prev.chat"),
-        Binding("ctrl+x", "delete_chat", "delete chat", id="delete.chat"),
+        Binding("ctrl+backspace", "delete_chat", "delete chat", id="delete.chat"),
         Binding("ctrl+n", "new_chat", "new chat", id="new.chat"),
         Binding("ctrl+q", "quit", "quit", id="quit"),
     ]


### PR DESCRIPTION
the 2 key bindings seems to have been left out. Since it is trivial to add them in, here it is. 