### PR TITLE
Persist images in message history / sqlite db.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 0.7.0 - 
 -------------------
 
+- Enforce foreign key constraints in the sqlite db, to allow proper cascading deletes.
+  [ggozad]
+
 - Perist images in the chat history & sqlite db.
   [ggozad]
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 0.7.0 - 
 -------------------
 
+- Perist images in the chat history & sqlite db.
+  [ggozad]
+
 - Update OllamaLLM client to match the use of Pydantic in olllama-python.
   [ggozad]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oterm"
-version = "0.6.9"
+version = "0.7.0"
 description = "A text-based terminal client for Ollama."
 authors = [{ name = "Yiorgis Gozadinos", email = "ggozadinos@gmail.com" }]
 license = { text = "MIT" }

--- a/src/oterm/app/chat_export.py
+++ b/src/oterm/app/chat_export.py
@@ -41,12 +41,12 @@ class ChatExport(ModalScreen[str]):
         if not event.value:
             return
 
-        messages: Sequence[tuple[int, Author, str]] = await store.get_messages(
-            self.chat_id
+        messages: Sequence[tuple[int, Author, str, list[str]]] = (
+            await store.get_messages(self.chat_id)
         )
         with open(event.value, "w", encoding="utf-8") as file:
             for message in messages:
-                _, author, text = message
+                _, author, text, images = message
                 file.write(f"*{author.value}*\n")
                 file.write(f"{text}\n")
                 file.write("\n---\n")

--- a/src/oterm/store/store.py
+++ b/src/oterm/store/store.py
@@ -218,7 +218,12 @@ class Store(object):
             await connection.commit()
 
     async def save_message(
-        self, id: int | None, chat_id: int, author: str, text: str, images: list[str]
+        self,
+        id: int | None,
+        chat_id: int,
+        author: str,
+        text: str,
+        images: list[str] = [],
     ) -> int:
         async with aiosqlite.connect(self.db_path) as connection:
             res = await connection.execute_insert(

--- a/src/oterm/store/store.py
+++ b/src/oterm/store/store.py
@@ -214,6 +214,7 @@ class Store(object):
 
     async def delete_chat(self, id: int) -> None:
         async with aiosqlite.connect(self.db_path) as connection:
+            await connection.execute("PRAGMA foreign_keys = on;")
             await connection.execute("DELETE FROM chat WHERE id = :id;", {"id": id})
             await connection.commit()
 

--- a/src/oterm/store/upgrades/__init__.py
+++ b/src/oterm/store/upgrades/__init__.py
@@ -7,6 +7,7 @@ from oterm.store.upgrades.v0_3_0 import upgrades as v0_3_0_upgrades
 from oterm.store.upgrades.v0_4_0 import upgrades as v0_4_0_upgrades
 from oterm.store.upgrades.v0_5_1 import upgrades as v0_5_1_upgrades
 from oterm.store.upgrades.v0_6_0 import upgrades as v0_6_0_upgrades
+from oterm.store.upgrades.v0_7_0 import upgrades as v0_7_0_upgrades
 
 upgrades = (
     v0_1_6_upgrades
@@ -18,4 +19,5 @@ upgrades = (
     + v0_4_0_upgrades
     + v0_5_1_upgrades
     + v0_6_0_upgrades
+    + v0_7_0_upgrades
 )

--- a/src/oterm/store/upgrades/v0_7_0.py
+++ b/src/oterm/store/upgrades/v0_7_0.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from typing import Awaitable, Callable
+
+import aiosqlite
+
+
+async def tools(db_path: Path) -> None:
+    async with aiosqlite.connect(db_path) as connection:
+        try:
+            await connection.executescript(
+                """
+                ALTER TABLE message ADD COLUMN images TEXT DEFAULT "[]";
+                """
+            )
+        except aiosqlite.OperationalError:
+            pass
+
+        await connection.commit()
+
+
+upgrades: list[tuple[str, list[Callable[[Path], Awaitable[None]]]]] = [
+    ("0.7.0", [tools])
+]

--- a/uv.lock
+++ b/uv.lock
@@ -628,7 +628,7 @@ wheels = [
 
 [[package]]
 name = "oterm"
-version = "0.6.9"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosql" },


### PR DESCRIPTION
* Persist images in sqlite and in the client's message history to allow them as context to the chat.
* Fix a bug where because foreign keys are not enforced by default on sqlite, messages were not deleted when a chat was deleted.