### PR TITLE
Only add param if Ollama Options accepts it

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.7.3 - 2025-01-05
+------------------
+
+- Fix parameter parsing / Options bug
+  [lorenmh]
+
 0.7.2 - 2025-01-03
 ------------------
 

--- a/src/oterm/ollamaclient.py
+++ b/src/oterm/ollamaclient.py
@@ -181,6 +181,7 @@ class OllamaLLM:
 def parse_ollama_parameters(parameter_text: str) -> Options:
     lines = parameter_text.split("\n")
     params = Options()
+    valid_params = set(Options.model_fields.keys())
     for line in lines:
         if line:
             key, value = line.split(maxsplit=1)
@@ -188,6 +189,8 @@ def parse_ollama_parameters(parameter_text: str) -> Options:
                 value = literal_eval(value)
             except (SyntaxError, ValueError):
                 pass
+            if key not in valid_params:
+                continue
             if params.get(key):
                 if not isinstance(params[key], list):
                     params[key] = [params[key], value]


### PR DESCRIPTION
From #152

Simple and possible naive fix, but PR adds a check to make sure parameters can be set in ollama Options before setting them.

[Seems there's a similar check here](https://github.com/ggozad/oterm/blob/2a347a6e0cd426a112c16369f348c0ec6206d04c/src/oterm/app/chat_edit.py#L75-L80), maybe can consolidate it somehow as well.

Ran locally and fixes the issue I was experiencing in #152