### PR TITLE
Deepseek r1 thought support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.8.1 - 2025-01-29
+------------------
+
+- Support for thinking models (e.g. DeepSeek R1).
+  [liorm]
+
 0.8.0 - 2025-01-19
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oterm"
-version = "0.8.0"
+version = "0.8.1"
 description = "A text-based terminal client for Ollama."
 authors = [{ name = "Yiorgis Gozadinos", email = "ggozadinos@gmail.com" }]
 license = { text = "MIT" }

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -68,10 +68,9 @@ class ChatContainer(Widget):
         # See https://github.com/ollama/ollama-python/issues/375
         # Temp fix is to do msg.images = images  # type: ignore
         for _, author, message, images in messages:
-            parsed = parse_response(message)
             msg = Message(
                 role="user" if author == Author.USER else "assistant",
-                content=message  if author == Author.USER else parsed["response"],
+                content=message  if author == Author.USER else parse_response(message)["response"],
             )
             msg.images = images  # type: ignore
             history.append(msg)
@@ -98,7 +97,7 @@ class ChatContainer(Widget):
         self.keep_alive = keep_alive
         self.tools = tools
         self.loaded = False
-        self.loading = False;
+        self.loading = False
         self.images = []
 
     def on_mount(self) -> None:
@@ -110,9 +109,8 @@ class ChatContainer(Widget):
         self.loading = True
         message_container = self.query_one("#messageContainer")
         for _, author, message, images in self.messages:
-            parsed = parse_response(message)
             chat_item = ChatItem()
-            chat_item.text = message if author == Author.USER else parsed["formatted_output"]
+            chat_item.text = message if author == Author.USER else parse_response(message)["formatted_output"]
             chat_item.author = author
             await message_container.mount(chat_item)
         message_container.scroll_end()

--- a/src/oterm/types.py
+++ b/src/oterm/types.py
@@ -9,6 +9,12 @@ class Author(Enum):
     OLLAMA = "ollama"
 
 
+class ParsedResponse(TypedDict):
+    thought: str
+    response: str
+    formatted_output: str
+
+
 class ToolDefinition(TypedDict):
     tool: Tool
     callable: Callable | Awaitable

--- a/src/oterm/utils.py
+++ b/src/oterm/utils.py
@@ -23,7 +23,7 @@ def parse_response(input_text: str) -> ParsedResponse:
         if len(thought) == 0:
             formatted_output = response
         else:
-            formatted_output = "> ### Thought\n" + "\n".join([f"> {line}" for line in thought.split("\n")]) + "\n\n" + response
+            formatted_output = "> ### \<think\>\n" + "\n".join([f"> {line}" for line in thought.split("\n")]) + "\n> ### \</think\>\n" + response
 
     return ParsedResponse(thought=thought, response=response, formatted_output=formatted_output)
 

--- a/src/oterm/utils.py
+++ b/src/oterm/utils.py
@@ -23,7 +23,7 @@ def parse_response(input_text: str) -> ParsedResponse:
         if len(thought) == 0:
             formatted_output = response
         else:
-            formatted_output = "### Thought\n" + thought + "\n\n---\n\n" + response
+            formatted_output = "> ### Thought\n" + "\n".join([f"> {line}" for line in thought.split("\n")]) + "\n\n" + response
 
     return ParsedResponse(thought=thought, response=response, formatted_output=formatted_output)
 

--- a/src/oterm/utils.py
+++ b/src/oterm/utils.py
@@ -1,6 +1,32 @@
 import sys
 from pathlib import Path
 
+from oterm.types import ParsedResponse
+
+
+def parse_response(input_text: str) -> ParsedResponse:
+    """
+    Parse a response from the chatbot.
+    """
+
+    thought = ""
+    response = input_text
+    formatted_output = input_text
+
+    # If the response contains a think tag, split the response into the thought process and the actual response
+    if input_text.startswith("<think>") and input_text.find("</think>") != -1:
+        thought = input_text[input_text.find("<think>") + 7: input_text.find("</think>")].lstrip("\n").rstrip(
+            "\n").strip()
+        response = input_text[input_text.find("</think>") + 8:].lstrip("\n").rstrip("\n")
+
+        # transform the think tag into a markdown blockquote (for clarity)
+        if len(thought) == 0:
+            formatted_output = response
+        else:
+            formatted_output = "### Thought\n" + thought + "\n\n---\n\n" + response
+
+    return ParsedResponse(thought=thought, response=response, formatted_output=formatted_output)
+
 
 def get_default_data_dir() -> Path:
     """


### PR DESCRIPTION
Added support for the deepseek R1 `<think>` and `</think>` tags. 
1. They were not rendered at all - so it was difficult to distinguish thought from actual response.
2. Common practice is to remove the thought from the context history, to conserve tokens.

