### PR TITLE
Long-running MCP servers , MCP server logging

### DIFF
--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -15,7 +15,7 @@ from oterm.app.splash import splash
 from oterm.app.widgets.chat import ChatContainer
 from oterm.config import appConfig
 from oterm.store.store import Store
-from oterm.tools import setup_mcp_servers
+from oterm.tools import setup_mcp_servers, teardown_mcp_servers
 
 
 class OTerm(App):
@@ -65,6 +65,7 @@ class OTerm(App):
         )
 
     async def action_quit(self) -> None:
+        await teardown_mcp_servers()
         return self.exit()
 
     async def action_cycle_chat(self, change: int) -> None:

--- a/src/oterm/tools/__init__.py
+++ b/src/oterm/tools/__init__.py
@@ -50,24 +50,31 @@ external_tools = appConfig.get("tools")
 if external_tools:
     available.extend(load_tools(external_tools))
 
+client_list = [ ]
 
 async def setup_mcp_servers():
     mcp_servers = appConfig.get("mcpServers")
     tool_defs: list[ToolDefinition] = []
     if mcp_servers:
         for server, config in mcp_servers.items():
+            # OPEN A LOG FOR THIS SERVER using the same naming Claude Desktop does
+            errlog = open(f"mcp-server-{server}.log", "w")
+            print(f"==== Starting {server} ====\n", file=errlog)
+            errlog.flush()
             async with MCPClient(
-                StdioServerParameters.model_validate(config)
+                StdioServerParameters.model_validate(config), errlog=errlog
             ) as client:
                 mcp_tools: list[MCPTool] = await client.get_available_tools()
+                client_list.append(client)
 
                 for mcp_tool in mcp_tools:
                     tool = mcp_tool_to_ollama_tool(mcp_tool)
 
                     async def callable(name=mcp_tool.name, **kwargs):
-                        async with MCPClient(
-                            StdioServerParameters.model_validate(config)
-                        ) as cl:
+                        async with client as cl:
+                            # TO REMOVE THESE TWO LINES
+                            print(f"==== Call Tool {name} ====\n", file=errlog)
+                            errlog.flush()
                             res: CallToolResult = await cl.call_tool(name, kwargs)
                             if res.isError:
                                 raise Exception(f"Error call mcp tool {name}.")
@@ -79,3 +86,9 @@ async def setup_mcp_servers():
                     tool_defs.append({"tool": tool, "callable": callable})
 
     return tool_defs
+
+
+async def teardown_mcp_servers():
+    for client in client_list:
+        await client.session.__aexit__(None, None, None)
+        await client._client.__aexit__(None, None, None)

--- a/src/oterm/tools/mcp.py
+++ b/src/oterm/tools/mcp.py
@@ -9,25 +9,27 @@ from oterm.types import Tool
 class MCPClient:
     """Client for interacting with MCP servers"""
 
-    def __init__(self, server_params: StdioServerParameters):
+    def __init__(self, server_params: StdioServerParameters, errlog=None):
         self.server_params = server_params
         self.session = None
         self._client = None
+        self.errlog = errlog
 
     async def __aenter__(self):
         """Async context manager entry"""
-        await self.connect()
+        if not self._client:
+            await self.connect()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Async context manager exit"""
-        if self.session:
-            await self.session.__aexit__(exc_type, exc_val, exc_tb)
-        if self._client:
-            await self._client.__aexit__(exc_type, exc_val, exc_tb)
+#        if self.session:
+#            await self.session.__aexit__(exc_type, exc_val, exc_tb)
+#        if self._client:
+#            await self._client.__aexit__(exc_type, exc_val, exc_tb)
 
     async def connect(self):
-        self._client = stdio_client(self.server_params)
+        self._client = stdio_client(self.server_params, errlog=self.errlog)
         self.read, self.write = await self._client.__aenter__()
         session = ClientSession(self.read, self.write)
         self.session = await session.__aenter__()

--- a/src/oterm/tools/mcp.py
+++ b/src/oterm/tools/mcp.py
@@ -29,7 +29,7 @@ class MCPClient:
 
         try:
             stdio_transport = await self.exit_stack.enter_async_context(
-                stdio_client(self.server_params, errlog=self.errlog)
+                stdio_client(self.server_params)
             )
             read, write = stdio_transport
             session = await self.exit_stack.enter_async_context(

--- a/src/oterm/tools/mcp.py
+++ b/src/oterm/tools/mcp.py
@@ -3,53 +3,116 @@ from mcp import Tool as MCPTool
 from mcp.client.stdio import stdio_client
 from mcp.types import CallToolResult
 
+from contextlib import AsyncExitStack
+from typing import Any
+import asyncio
+
 from oterm.types import Tool
 
+import logging
+logger = logging.getLogger(__name__)
 
+# adapted from mcp-python-sdk/examples/clients/simple-chatbot/mcp_simple_chatbot/main.py
 class MCPClient:
-    """Client for interacting with MCP servers"""
+    """Manages MCP server connections and tool execution."""
 
     def __init__(self, server_params: StdioServerParameters, errlog=None):
         self.server_params = server_params
-        self.session = None
-        self._client = None
         self.errlog = errlog
+        self.stdio_context: Any | None = None
+        self.session: ClientSession | None = None
+        self._cleanup_lock: asyncio.Lock = asyncio.Lock()
+        self.exit_stack: AsyncExitStack = AsyncExitStack()
 
-    async def __aenter__(self):
-        """Async context manager entry"""
-        if not self._client:
-            await self.connect()
-        return self
+    async def initialize(self) -> None:
+        """Initialize the server connection."""
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Async context manager exit"""
-#        if self.session:
-#            await self.session.__aexit__(exc_type, exc_val, exc_tb)
-#        if self._client:
-#            await self._client.__aexit__(exc_type, exc_val, exc_tb)
-
-    async def connect(self):
-        self._client = stdio_client(self.server_params, errlog=self.errlog)
-        self.read, self.write = await self._client.__aenter__()
-        session = ClientSession(self.read, self.write)
-        self.session = await session.__aenter__()
-        await self.session.initialize()
+        try:
+            stdio_transport = await self.exit_stack.enter_async_context(
+                stdio_client(self.server_params, errlog=self.errlog)
+            )
+            read, write = stdio_transport
+            session = await self.exit_stack.enter_async_context(
+                ClientSession(read, write)
+            )
+            await session.initialize()
+            self.session = session
+        except Exception as e:
+            logging.error(f"Error initializing server {self.name}: {e}")
+            await self.cleanup()
+            raise
 
     async def get_available_tools(self) -> list[MCPTool]:
-        """List available tools"""
+        """List available tools from the server.
+
+        Returns:
+            A list of available tools.
+
+        Raises:
+            RuntimeError: If the server is not initialized.
+        """
         if not self.session:
-            raise RuntimeError("Not connected to MCP server")
-        tools: ListToolsResult = await self.session.list_tools()
+            raise RuntimeError(f"Server {self.name} not initialized")
+
+        tools_response = await self.session.list_tools()
+
         # Let's just ignore pagination for now
-        return tools.tools
+        return tools_response.tools
 
-    async def call_tool(self, tool_name: str, arguments: dict) -> CallToolResult:
-        """Call a tool with given arguments"""
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        retries: int = 2,
+        delay: float = 1.0,
+    ) -> Any:
+        """Execute a tool with retry mechanism.
+
+        Args:
+            tool_name: Name of the tool to execute.
+            arguments: Tool arguments.
+            retries: Number of retry attempts.
+            delay: Delay between retries in seconds.
+
+        Returns:
+            Tool execution result.
+
+        Raises:
+            RuntimeError: If server is not initialized.
+            Exception: If tool execution fails after all retries.
+        """
         if not self.session:
-            raise RuntimeError("Not connected to MCP server")
+            raise RuntimeError(f"Server {self.name} not initialized")
 
-        result = await self.session.call_tool(tool_name, arguments=arguments)
-        return result
+        attempt = 0
+        while attempt < retries:
+            try:
+                logging.info(f"Executing {tool_name}...")
+                result = await self.session.call_tool(tool_name, arguments)
+
+                return result
+
+            except Exception as e:
+                attempt += 1
+                logging.warning(
+                    f"Error executing tool: {e}. Attempt {attempt} of {retries}."
+                )
+                if attempt < retries:
+                    logging.info(f"Retrying in {delay} seconds...")
+                    await asyncio.sleep(delay)
+                else:
+                    logging.error("Max retries reached. Failing.")
+                    raise
+
+    async def cleanup(self) -> None:
+        """Clean up server resources."""
+        async with self._cleanup_lock:
+            try:
+                await self.exit_stack.aclose()
+                self.session = None
+                self.stdio_context = None
+            except Exception as e:
+                logging.error(f"Error during cleanup of server {self.name}: {e}")
 
 
 def mcp_tool_to_ollama_tool(mcp_tool: MCPTool) -> Tool:

--- a/tests/tools/example_mcp_server.py
+++ b/tests/tools/example_mcp_server.py
@@ -1,0 +1,26 @@
+#
+# Small Demo server using FastMCP and illustrating debugging and notification streams
+#
+
+import logging
+from mcp.server.fastmcp import FastMCP, Context
+import time
+import asyncio
+
+mcp = FastMCP("MCP EXAMPLE SERVER", debug=True, log_level="DEBUG")
+
+logger = logging.getLogger(__name__)
+
+logger.debug(f"MCP STARTING EXAMPLE SERVER")
+
+@mcp.resource("config://app")
+def get_config() -> str:
+    """Static configuration data"""
+    return "Tom5 Server 2024-02-25"
+
+@mcp.tool()
+async def simple_tool(x:float, y:float, ctx:Context) -> str:
+    logger.debug("IN SIMPLE_TOOL")
+    ctx.report_progress(1, 2)
+    return x*y
+

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1,0 +1,73 @@
+import pytest
+
+import os
+import sys
+from oterm.ollamaclient import OllamaLLM
+from oterm.tools import MCPClient, McpToolCallable
+from oterm.types import Tool
+
+from mcp import StdioServerParameters
+
+# locate the exmaple MCP server co-located in this directory
+
+mcp_server_dir = os.path.dirname(os.path.abspath(__file__))
+mcp_server_file = os.path.join(mcp_server_dir, "example_mcp_server.py")
+                           
+# mcpServers config in same syntax used by reference MCP
+
+servers_config = {
+    "mcpServers": {
+
+        "testMcpServer": {
+            "command": "mcp",   # be sure to . .venv/bin/activate so that mcp command is found
+            "args": [
+                "run",
+                mcp_server_file
+            ]
+        }
+
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_mcp():
+
+    servers = servers_config.get("mcpServers")
+
+    server0 = "testMcpServer"
+    config0 = servers[server0]
+    
+    client = MCPClient(
+        StdioServerParameters.model_validate(config0)
+    )
+    await client.initialize()
+    tools = await client.get_available_tools()
+
+    # print(f"TOOLS:{tools}")
+    mcp_tool = tools[0]
+
+    # create an Ollama tool referencing the MCP tool in the MCP server
+    oterm_tool = Tool(
+        function=Tool.Function(
+            name=mcp_tool.name,
+            description=mcp_tool.description,
+            parameters=Tool.Function.Parameters.model_validate(mcp_tool.inputSchema),
+            ),
+        )
+
+    mcpToolCallable = McpToolCallable(mcp_tool.name, server0, client)
+
+    llm = OllamaLLM(
+        tool_defs=[{"tool": oterm_tool, "callable": mcpToolCallable.call}],
+    )
+
+    res = await llm.completion(
+        "Please call my simple-tool with values 12 and 25."
+    )
+    
+    print(f"COMPLETION:{res}")
+    assert "300" in res
+
+    # clients must be destroyed in reverse order
+    await client.cleanup()


### PR DESCRIPTION
This PR is a suggestion for how to make MCP servers long running.  There may be a cleaner way to do it and you may want to rewrite this.
(But first of all - oterm mcp is great work and I'm using it with llama3.2 :-)

Also, to see what was going on I needed to add debugging logs to MCP and that is described in this PR there: https://github.com/modelcontextprotocol/python-sdk/pull/191

Problem: each call to list-tools or call/tool restarts the python script.  With Claude Desktop, servers are long-running and calls to tools are messages sent to that server.  My modification keeps the session running and does not restart it if there is already one running.  But to do that, an explicit teardown needed to be added.

To Test:
include the "simple_tool" attached and ask ollama:
"Please call the simple tool with 100 and 200."
"Now call it with 250 and 350"

The per-server log is named "mcp-server-Tom5Server.log" and its contents are the following.  Note that the server is called once and the tool is invoked twice.

```
==== Starting Tom5Server ====

[02/05/25 13:11:02] DEBUG    MCP STARTING SERVER TOM5           tom5server.py:14
                    DEBUG    Adding resource              resource_manager.py:32
                    DEBUG    Using selector:               selector_events.py:59
                             KqueueSelector                                     
                    DEBUG    Received message:                     server.py:432
                             root=InitializedNotification(method='              
                             notifications/initialized',                        
                             params=None, jsonrpc='2.0')                        
                    DEBUG    Received message:                     server.py:432
                             <mcp.shared.session.RequestResponder               
                             object at 0x104feedd0>                             
                    INFO     Processing request of type            server.py:454
                             ListToolsRequest                                   
                    DEBUG    Dispatching request of type           server.py:457
                             ListToolsRequest                                   
                    DEBUG    Response sent                         server.py:491
==== Call Tool simple_tool ====

[02/05/25 13:11:16] DEBUG    Received message:                     server.py:432
                             <mcp.shared.session.RequestResponder               
                             object at 0x104fee0b0>                             
                    INFO     Processing request of type            server.py:454
                             CallToolRequest                                    
                    DEBUG    Dispatching request of type           server.py:457
                             CallToolRequest                                    
                    DEBUG    IN SIMPLE_TOOL                     tom5server.py:23
                    DEBUG    Response sent                         server.py:491
                    INFO     Warning: RuntimeWarning: coroutine    server.py:443
                             'Context.report_progress' was never                
                             awaited                                            
==== Call Tool simple_tool ====

[02/05/25 13:11:38] DEBUG    Received message:                     server.py:432
                             <mcp.shared.session.RequestResponder               
                             object at 0x104fee830>                             
                    INFO     Processing request of type            server.py:454
                             CallToolRequest                                    
                    DEBUG    Dispatching request of type           server.py:457
                             CallToolRequest                                    
                    DEBUG    IN SIMPLE_TOOL                     tom5server.py:23
                    DEBUG    Response sent                         server.py:491
                    INFO     Warning: RuntimeWarning: coroutine    server.py:443
                             'Context.report_progress' was never                
                             awaited                                            

```

The source for the MCP server is this
```
#
# Small Demo server using FastMCP and illustrating debugging and notification streams
#

import logging
from mcp.server.fastmcp import FastMCP, Context
import time
import asyncio

mcp = FastMCP("Tom5 Server 2024-02-05", debug=True, log_level="DEBUG")

logger = logging.getLogger(__name__)

logger.debug(f"MCP STARTING SERVER TOM5")

@mcp.resource("config://app")
def get_config() -> str:
    """Static configuration data"""
    return "Tom5 Server 2024-02-25"

@mcp.tool()
async def simple_tool(x:float, y:float, ctx:Context) -> str:
    logger.debug("IN SIMPLE_TOOL")
    ctx.report_progress(1, 2)
    return x*y

```

