### PR TITLE
explicitly enable '-h' short-form help option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ Changelog
 
 0.9.2 - 
 ------------------
+- Enable '-h' short-form help option.
+  [brucewillke]
 
 - Fix checking latest version on pypi.
   [ggozad]

--- a/src/oterm/cli/oterm.py
+++ b/src/oterm/cli/oterm.py
@@ -8,7 +8,8 @@ from oterm.app.oterm import app
 from oterm.config import envConfig
 from oterm.store.store import Store
 
-cli = typer.Typer()
+cli = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
+
 
 
 async def upgrade_db():


### PR DESCRIPTION
This PR explicitly enables the short-form -h option for displaying help messages. By default, oterm currently supports only the --help flag. This change enhances usability by allowing users to use the familiar -h shortcut to access command-line help. 