### PR TITLE
Introduce "thinking" option for reasoning models & show model capabilities when editing/creating a chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oterm"
-version = "0.13.0"
+version = "0.13.1"
 description = "A text-based terminal client for Ollama."
 authors = [{ name = "Yiorgis Gozadinos", email = "ggozadinos@gmail.com" }]
 license = { text = "MIT" }

--- a/src/oterm/app/chat_edit.py
+++ b/src/oterm/app/chat_edit.py
@@ -104,7 +104,6 @@ class ChatEdit(ModalScreen[str]):
             parameters=parameters,
             keep_alive=keep_alive,
             tools=self.tools,
-            type=self.chat_model.type,
         )
 
         self.dismiss(updated_chat_model.model_dump_json(exclude_none=True))

--- a/src/oterm/app/chat_edit.py
+++ b/src/oterm/app/chat_edit.py
@@ -9,7 +9,7 @@ from textual.containers import (
 )
 from textual.reactive import reactive
 from textual.screen import ModalScreen
-from textual.widgets import Button, Input, Label, OptionList, TextArea
+from textual.widgets import Button, Checkbox, Input, Label, OptionList, TextArea
 
 from oterm.app.widgets.tool_select import ToolSelector
 from oterm.ollamaclient import (
@@ -36,6 +36,7 @@ class ChatEdit(ModalScreen[str]):
     last_highlighted_index = None
     tools: reactive[list[Tool]] = reactive([])
     edit_mode: reactive[bool] = reactive(False)
+    thinking: reactive[bool] = reactive(True)
 
     BINDINGS = [
         ("escape", "cancel", "Cancel"),
@@ -62,6 +63,7 @@ class ChatEdit(ModalScreen[str]):
         self.keep_alive = chat_model.keep_alive
         self.tools = chat_model.tools
         self.edit_mode = edit_mode
+        self.thinking = chat_model.thinking
 
     def _return_chat_meta(self) -> None:
         model = f"{self.model_name}:{self.tag}"
@@ -93,6 +95,7 @@ class ChatEdit(ModalScreen[str]):
             return
 
         self.tools = self.query_one(ToolSelector).selected
+        self.thinking = self.query_one("#thinking-checkbox", Checkbox).value
 
         # Create updated chat model
         updated_chat_model = ChatModel(
@@ -104,6 +107,7 @@ class ChatEdit(ModalScreen[str]):
             parameters=parameters,
             keep_alive=keep_alive,
             tools=self.tools,
+            thinking=self.thinking,
         )
 
         self.dismiss(updated_chat_model.model_dump_json(exclude_none=True))
@@ -244,6 +248,12 @@ class ChatEdit(ModalScreen[str]):
                             )
                             yield Input(
                                 classes="keep-alive", value=str(self.keep_alive)
+                            )
+                            yield Checkbox(
+                                "Thinking",
+                                id="thinking-checkbox",
+                                name="thinking",
+                                value=self.thinking,
                             )
 
             with Horizontal(classes="button-container"):

--- a/src/oterm/app/chat_edit.py
+++ b/src/oterm/app/chat_edit.py
@@ -173,10 +173,19 @@ class ChatEdit(ModalScreen[str]):
             # XXX Does not work as expected, there is no longer system in model_info
             widget.load_text(self.system or self.model_info.get("system", ""))
 
-            # Deduce from the model's template if the model is tool-capable.
-            tools_supported = ".Tools" in self.model_info["template"]
+            capabilities: list[str] = self.model_info.get("capabilities", [])
+            tools_supported = "tools" in capabilities
             tool_selector = self.query_one(ToolSelector)
             tool_selector.disabled = not tools_supported
+
+            if "completion" in capabilities:
+                capabilities.remove("completion")  #
+            if "embedding" in capabilities:
+                capabilities.remove("embedding")
+
+            caps = ", ".join(capabilities).replace("vision", "👁️").replace("tools", "🛠️")
+            widget = self.query_one(".caps", Label)
+            widget.update(caps)
 
         # Now that there is a model selected we can save the chat.
         save_button = self.query_one("#save-btn", Button)
@@ -204,6 +213,8 @@ class ChatEdit(ModalScreen[str]):
                         yield Label(f"{self.tag}", classes="tag")
                         yield Label("Size:", classes="title")
                         yield Label(f"{self.size}", classes="size")
+                        yield Label("Caps:", classes="title")
+                        yield Label("", classes="caps")
 
                     yield OptionList(id="model-select")
                     yield Label("Tools:", classes="title")

--- a/src/oterm/store/upgrades/__init__.py
+++ b/src/oterm/store/upgrades/__init__.py
@@ -10,6 +10,7 @@ from oterm.store.upgrades.v0_6_0 import upgrades as v0_6_0_upgrades
 from oterm.store.upgrades.v0_7_0 import upgrades as v0_7_0_upgrades
 from oterm.store.upgrades.v0_9_0 import upgrades as v0_9_0_upgrades
 from oterm.store.upgrades.v0_12_0 import upgrades as v0_12_0_upgrades
+from oterm.store.upgrades.v0_13_1 import upgrades as v0_13_1_upgrades
 
 upgrades = (
     v0_1_6_upgrades
@@ -24,4 +25,5 @@ upgrades = (
     + v0_7_0_upgrades
     + v0_9_0_upgrades
     + v0_12_0_upgrades
+    + v0_13_1_upgrades
 )

--- a/src/oterm/store/upgrades/v0_13_1.py
+++ b/src/oterm/store/upgrades/v0_13_1.py
@@ -35,6 +35,15 @@ async def remove_type_column(db_path: Path) -> None:
         )
 
 
+async def add_thinking_column(db_path):
+    """Add thinking column to chat table."""
+    async with aiosqlite.connect(db_path) as connection:
+        await connection.execute(
+            "ALTER TABLE chat ADD COLUMN thinking BOOLEAN DEFAULT 1"
+        )
+        await connection.commit()
+
+
 upgrades: list[tuple[str, list[Callable[[Path], Awaitable[None]]]]] = [
-    ("0.13.1", [remove_type_column])
+    ("0.13.1", [remove_type_column, add_thinking_column])
 ]

--- a/src/oterm/store/upgrades/v0_13_1.py
+++ b/src/oterm/store/upgrades/v0_13_1.py
@@ -1,0 +1,40 @@
+# Example upgrade script to remove type column from chat table
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import aiosqlite
+
+
+async def remove_type_column(db_path: Path) -> None:
+    async with aiosqlite.connect(db_path) as connection:
+        await connection.executescript(
+            """
+            BEGIN TRANSACTION;
+
+            CREATE TABLE chat_new (
+                "id"        INTEGER,
+                "name"      TEXT,
+                "model"     TEXT NOT NULL,
+                "system"    TEXT,
+                "format"    TEXT,
+                "parameters" TEXT DEFAULT "{}",
+                "keep_alive" INTEGER DEFAULT 5,
+                "tools"     TEXT DEFAULT "[]",
+                PRIMARY KEY("id" AUTOINCREMENT)
+            );
+
+            INSERT INTO chat_new(id, name, model, system, format, parameters, keep_alive, tools)
+            SELECT id, name, model, system, format, parameters, keep_alive, tools FROM chat;
+
+            DROP TABLE chat;
+
+            ALTER TABLE chat_new RENAME TO chat;
+
+            COMMIT;
+            """
+        )
+
+
+upgrades: list[tuple[str, list[Callable[[Path], Awaitable[None]]]]] = [
+    ("0.13.1", [remove_type_column])
+]

--- a/src/oterm/types.py
+++ b/src/oterm/types.py
@@ -49,6 +49,7 @@ class ChatModel(BaseModel):
     parameters: OtermOllamaOptions = Field(default_factory=OtermOllamaOptions)
     keep_alive: int = 5
     tools: list[Tool] = Field(default_factory=list)
+    thinking: bool = True
 
 
 class MessageModel(BaseModel):

--- a/src/oterm/types.py
+++ b/src/oterm/types.py
@@ -49,7 +49,6 @@ class ChatModel(BaseModel):
     parameters: OtermOllamaOptions = Field(default_factory=OtermOllamaOptions)
     keep_alive: int = 5
     tools: list[Tool] = Field(default_factory=list)
-    type: str = "chat"
 
 
 class MessageModel(BaseModel):

--- a/tests/test_ollama_api.py
+++ b/tests/test_ollama_api.py
@@ -13,14 +13,17 @@ def test_list():
 
 def test_show():
     llm = OllamaLLM()
-    response = llm.show("llama3.2")
+    response = llm.show("llama3.2:latest")
     assert response
     assert response.modelfile
     assert response.parameters
     assert response.template
     assert response.details
     assert response.modelinfo
+    assert response.capabilities
 
+    assert "tools" in response.capabilities
+    assert "completion" in response.capabilities
     params = parse_ollama_parameters(response.parameters)
     assert params.stop == ["<|start_header_id|>", "<|end_header_id|>", "<|eot_id|>"]
     assert params.temperature is None

--- a/uv.lock
+++ b/uv.lock
@@ -982,7 +982,7 @@ wheels = [
 
 [[package]]
 name = "oterm"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosql" },


### PR DESCRIPTION
* Uses the new thinking parameter in Ollama to disable/enable thinking for models that support it.
* Detects model capabilities (tools, vision etc) and shows them in the model selection

Closes #242 