### PR TITLE
Fix store migration idempotency and persist user_version

### DIFF
--- a/src/oterm/store/store.py
+++ b/src/oterm/store/store.py
@@ -80,6 +80,7 @@ class Store:
             await connection.execute(
                 f"PRAGMA user_version = {semantic_version_to_int(version)};"
             )
+            await connection.commit()
 
     async def save_chat(self, chat_model: ChatModel) -> int:
         async with aiosqlite.connect(self.db_path) as connection:

--- a/src/oterm/store/upgrades/v0_13_1.py
+++ b/src/oterm/store/upgrades/v0_13_1.py
@@ -7,6 +7,11 @@ import aiosqlite
 
 async def remove_type_column(db_path: Path) -> None:
     async with aiosqlite.connect(db_path) as connection:
+        res = await connection.execute("PRAGMA table_info(chat);")
+        columns = {row[1] for row in await res.fetchall()}
+        if "type" not in columns:
+            return
+
         await connection.executescript(
             """
             BEGIN TRANSACTION;
@@ -38,9 +43,12 @@ async def remove_type_column(db_path: Path) -> None:
 async def add_thinking_column(db_path):
     """Add thinking column to chat table."""
     async with aiosqlite.connect(db_path) as connection:
-        await connection.execute(
-            "ALTER TABLE chat ADD COLUMN thinking BOOLEAN DEFAULT 0"
-        )
+        res = await connection.execute("PRAGMA table_info(chat);")
+        columns = {row[1] for row in await res.fetchall()}
+        if "thinking" in columns:
+            return
+
+        await connection.execute("ALTER TABLE chat ADD COLUMN thinking BOOLEAN DEFAULT 0")
         await connection.commit()
 
 

--- a/src/oterm/store/upgrades/v0_1_6.py
+++ b/src/oterm/store/upgrades/v0_1_6.py
@@ -6,12 +6,14 @@ import aiosqlite
 
 async def add_template_system_to_chat(db_path: Path) -> None:
     async with aiosqlite.connect(db_path) as connection:
-        await connection.executescript(
-            """
-            ALTER TABLE chat ADD COLUMN template TEXT;
-            ALTER TABLE chat ADD COLUMN system TEXT;
-            """
-        )
+        res = await connection.execute("PRAGMA table_info(chat);")
+        columns = {row[1] for row in await res.fetchall()}
+
+        if "template" not in columns:
+            await connection.execute("ALTER TABLE chat ADD COLUMN template TEXT;")
+        if "system" not in columns:
+            await connection.execute("ALTER TABLE chat ADD COLUMN system TEXT;")
+        await connection.commit()
 
 
 upgrades: list[tuple[str, list[Callable[[Path], Awaitable[None]]]]] = [


### PR DESCRIPTION
## Summary
- make the v0.1.6 migration idempotent by adding missing chat columns only when absent
- make v0.13.1 migration steps conditional so existing schemas don’t fail on startup
- commit PRAGMA user_version updates so migrations are not rerun on every launch

## Validation
- uv run ruff check src/oterm/store/store.py src/oterm/store/upgrades/v0_1_6.py src/oterm/store/upgrades/v0_13_1.py
- uv run pytest -q tests/test_store.py
- manual: uv run oterm starts without migration traceback against existing ~/.local/share/oterm/store.db
