### PR TITLE
feat: add MiniMax as cloud LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ the terminal client for [Ollama](https://github.com/ollama/ollama).
 * multiple persistent chat sessions, stored together with system prompt & parameter customizations in sqlite.
 * support for Model Context Protocol (MCP) tools & prompts integration.
 * can use any of the models you have pulled in Ollama, or your own custom models.
+* supports [MiniMax](https://www.minimaxi.com) cloud models (M2.7, M2.5) as an alternative provider — set `MINIMAX_API_KEY` to enable.
 * allows for easy customization of the model's system prompt and parameters.
 * supports tools integration for providing external information to the model.
 
@@ -24,6 +25,7 @@ See [Installation](https://ggozad.github.io/oterm/installation) for more details
 [oterm Documentation](https://ggozad.github.io/oterm/)
 
 ## What's new
+* [MiniMax](https://www.minimaxi.com) cloud provider support — use MiniMax-M2.7, M2.5 and highspeed models alongside Ollama.
 * [Example](https://ggozad.github.io/oterm/rag_example) on how to do RAG with [haiku.rag](https://github.com/ggozad/haiku.rag).
 * `oterm` is now part of Homebrew!
 * Support for "thinking" mode for models that support it.

--- a/src/oterm/app/chat_edit.py
+++ b/src/oterm/app/chat_edit.py
@@ -9,10 +9,12 @@ from textual.containers import (
 )
 from textual.reactive import reactive
 from textual.screen import ModalScreen
-from textual.widgets import Button, Checkbox, Input, Label, OptionList, TextArea
+from textual.widgets import Button, Checkbox, Input, Label, OptionList, RadioSet, TextArea
 
 from oterm.app.widgets.caps import Capabilities
 from oterm.app.widgets.tool_select import ToolSelector
+from oterm.config import envConfig
+from oterm.minimaxclient import MiniMaxLLM
 from oterm.ollamaclient import (
     OllamaLLM,
     jsonify_options,
@@ -24,12 +26,12 @@ from oterm.types import ChatModel, OtermOllamaOptions, Tool
 
 class ChatEdit(ModalScreen[str]):
     models = []
-    models_info: dict[str, ShowResponse] = {}
+    models_info: dict[str, ShowResponse | Any] = {}
 
     model_name: reactive[str] = reactive("")
     tag: reactive[str] = reactive("")
     bytes: reactive[int] = reactive(0)
-    model_info: ShowResponse
+    model_info: ShowResponse | Any = None
     system: reactive[str] = reactive("")
     parameters: reactive[Options] = reactive(Options())
     format: reactive[str] = reactive("")
@@ -38,6 +40,7 @@ class ChatEdit(ModalScreen[str]):
     tools: reactive[list[Tool]] = reactive([])
     edit_mode: reactive[bool] = reactive(False)
     thinking: reactive[bool] = reactive(False)
+    provider: reactive[str] = reactive("ollama")
 
     BINDINGS = [
         ("escape", "cancel", "Cancel"),
@@ -55,9 +58,9 @@ class ChatEdit(ModalScreen[str]):
             chat_model = ChatModel()
 
         self.chat_model = chat_model
-        self.model_name, self.tag = (
-            chat_model.model.split(":") if chat_model.model else ("", "")
-        )
+        parts = chat_model.model.split(":", 1) if chat_model.model else ["", ""]
+        self.model_name = parts[0]
+        self.tag = parts[1] if len(parts) > 1 else ""
         self.system = chat_model.system or ""
         self.parameters = chat_model.parameters
         self.format = chat_model.format
@@ -65,11 +68,15 @@ class ChatEdit(ModalScreen[str]):
         self.tools = chat_model.tools
         self.edit_mode = edit_mode
         self.thinking = chat_model.thinking
+        self.provider = chat_model.provider
 
     def _return_chat_meta(self) -> None:
-        model = f"{self.model_name}:{self.tag}"
+        if self.tag:
+            model = f"{self.model_name}:{self.tag}"
+        else:
+            model = self.model_name
         system = self.query_one(".system", TextArea).text
-        system = system if system != self.model_info.get("system", "") else None
+        system = system if system != (self.model_info.get("system", "") if self.model_info else "") else None
         keep_alive = int(self.query_one(".keep-alive", Input).value)
         p_area = self.query_one(".parameters", TextArea)
         try:
@@ -103,6 +110,7 @@ class ChatEdit(ModalScreen[str]):
             id=self.chat_model.id,
             name=self.chat_model.name,
             model=model,
+            provider=self.provider,
             system=system,
             format=format,
             parameters=parameters,
@@ -127,23 +135,55 @@ class ChatEdit(ModalScreen[str]):
                 break
 
     async def on_mount(self) -> None:
-        self.models = OllamaLLM.list().models
+        # Set initial provider in the RadioSet
+        radio_set = self.query_one("#provider-select", RadioSet)
+        if self.provider == "minimax":
+            radio_set.pressed_index = 1
+        else:
+            radio_set.pressed_index = 0
 
-        models = [model.model or "" for model in self.models]
-        for model in models:
-            info = OllamaLLM.show(model)
-            self.models_info[model] = info
+        self._load_models()
+
+        # Disable the model select widget if we are in edit mode.
+        widget = self.query_one("#model-select", OptionList)
+        widget.disabled = self.edit_mode
+
+    def _load_models(self) -> None:
+        """Load models for the currently selected provider."""
+        if self.provider == "minimax":
+            response = MiniMaxLLM.list()
+            self.models = response.models
+            models = [model.model or "" for model in self.models]
+            for model in models:
+                info = MiniMaxLLM.show(model)
+                self.models_info[model] = info
+        else:
+            self.models = OllamaLLM.list().models
+            models = [model.model or "" for model in self.models]
+            for model in models:
+                info = OllamaLLM.show(model)
+                self.models_info[model] = info
+
         option_list = self.query_one("#model-select", OptionList)
         option_list.clear_options()
         for model in models:
             option_list.add_option(option=self.model_option(model))
         option_list.highlighted = self.last_highlighted_index
-        if self.model_name and self.tag:
-            self.select_model(f"{self.model_name}:{self.tag}")
 
-        # Disable the model select widget if we are in edit mode.
-        widget = self.query_one("#model-select", OptionList)
-        widget.disabled = self.edit_mode
+        if self.model_name:
+            model_str = f"{self.model_name}:{self.tag}" if self.tag else self.model_name
+            self.select_model(model_str)
+
+    def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
+        """Handle provider selection change."""
+        provider = "minimax" if event.index == 1 else "ollama"
+        if provider != self.provider:
+            self.provider = provider
+            self.model_name = ""
+            self.tag = ""
+            self.models_info = {}
+            ChatEdit.last_highlighted_index = None
+            self._load_models()
 
     def on_option_list_option_highlighted(
         self, option: OptionList.OptionHighlighted
@@ -151,7 +191,9 @@ class ChatEdit(ModalScreen[str]):
         model = option.option.prompt
         model_meta = next((m for m in self.models if m.model == str(model)), None)
         if model_meta:
-            name, tag = (model_meta.model or "").split(":")
+            parts = (model_meta.model or "").split(":", 1)
+            name = parts[0]
+            tag = parts[1] if len(parts) > 1 else ""
             self.model_name = name
             widget = self.query_one(".name", Label)
             widget.update(f"{self.model_name}")
@@ -160,24 +202,29 @@ class ChatEdit(ModalScreen[str]):
             widget = self.query_one(".tag", Label)
             widget.update(f"{self.tag}")
 
-            self.bytes = model_meta["size"]
+            size = model_meta["size"] if "size" in model_meta.__dict__ or hasattr(model_meta, "size") else 0
+            self.bytes = size
             widget = self.query_one(".size", Label)
-            widget.update(f"{(self.bytes / 1.0e9):.2f} GB")
+            if size > 0:
+                widget.update(f"{(self.bytes / 1.0e9):.2f} GB")
+            else:
+                widget.update("cloud" if self.provider == "minimax" else "N/A")
 
             meta = self.models_info.get(model_meta.model or "")
             self.model_info = meta  # type: ignore
             if not self.edit_mode:
-                self.parameters = parse_ollama_parameters(
-                    self.model_info.parameters or ""
-                )
+                params_text = self.model_info.parameters or "" if self.model_info else ""
+                if self.provider == "ollama":
+                    self.parameters = parse_ollama_parameters(params_text)
+                else:
+                    self.parameters = Options()
             widget = self.query_one(".parameters", TextArea)
             widget.load_text(jsonify_options(self.parameters))
             widget = self.query_one(".system", TextArea)
 
-            # XXX Does not work as expected, there is no longer system in model_info
-            widget.load_text(self.system or self.model_info.get("system", ""))
+            widget.load_text(self.system or (self.model_info.get("system", "") if self.model_info else ""))
 
-            capabilities: list[str] = self.model_info.get("capabilities", [])
+            capabilities: list[str] = self.model_info.get("capabilities", []) if self.model_info else []
             tools_supported = "tools" in capabilities
             tool_selector = self.query_one(ToolSelector)
             tool_selector.disabled = not tools_supported
@@ -186,7 +233,7 @@ class ChatEdit(ModalScreen[str]):
             thinking_checkbox.disabled = "thinking" not in capabilities
 
             if "completion" in capabilities:
-                capabilities.remove("completion")  #
+                capabilities.remove("completion")
             if "embedding" in capabilities:
                 capabilities.remove("embedding")
 
@@ -212,6 +259,18 @@ class ChatEdit(ModalScreen[str]):
         with Container(classes="screen-container full-height"):
             with Horizontal():
                 with Vertical():
+                    with Horizontal(id="provider-info"):
+                        yield Label("Provider:", classes="title")
+                        with RadioSet(id="provider-select"):
+                            from textual.widgets import RadioButton
+
+                            yield RadioButton("Ollama", value=self.provider == "ollama")
+                            minimax_available = bool(envConfig.MINIMAX_API_KEY)
+                            yield RadioButton(
+                                "MiniMax",
+                                value=self.provider == "minimax",
+                                disabled=not minimax_available,
+                            )
                     with Horizontal(id="model-info"):
                         yield Label("Model:", classes="title")
                         yield Label(f"{self.model_name}", classes="name")

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -3,6 +3,7 @@ import json
 import random
 from pathlib import Path
 
+import httpx
 from ollama import Message, ResponseError
 from textual import on, work
 from textual.app import ComposeResult
@@ -24,6 +25,7 @@ from oterm.app.mcp_prompt import MCPPrompt
 from oterm.app.prompt_history import PromptHistory
 from oterm.app.widgets.image import ImageAdded
 from oterm.app.widgets.prompt import FlexibleInput
+from oterm.minimaxclient import MiniMaxLLM
 from oterm.ollamaclient import OllamaLLM, Options
 from oterm.store.store import Store
 from oterm.tools import available_tool_calls
@@ -32,7 +34,7 @@ from oterm.utils import parse_response
 
 
 class ChatContainer(Widget):
-    ollama = OllamaLLM()
+    ollama: OllamaLLM | MiniMaxLLM = OllamaLLM()
     messages: reactive[list[MessageModel]] = reactive([])
     images: list[tuple[Path, str]] = []
     BINDINGS = [
@@ -76,19 +78,41 @@ class ChatContainer(Widget):
             if tool_def["tool"] in chat_model.tools
         ]
 
-        self.ollama = OllamaLLM(
+        self.ollama = self._create_llm_client(
+            chat_model, history, used_tool_defs
+        )
+        self.loaded = False
+        self.loading = False
+        self.images = []
+
+    @staticmethod
+    def _create_llm_client(
+        chat_model: ChatModel,
+        history: list,
+        tool_defs: list,
+    ) -> OllamaLLM | MiniMaxLLM:
+        """Create the appropriate LLM client based on the provider."""
+        if chat_model.provider == "minimax":
+            return MiniMaxLLM(
+                model=chat_model.model,
+                system=chat_model.system,
+                history=history,
+                format=chat_model.format,
+                options=chat_model.parameters,
+                keep_alive=chat_model.keep_alive,
+                tool_defs=tool_defs,
+                thinking=chat_model.thinking,
+            )
+        return OllamaLLM(
             model=chat_model.model,
             system=chat_model.system,
             format=chat_model.format,
             options=chat_model.parameters,
             keep_alive=chat_model.keep_alive,
             history=history,
-            tool_defs=used_tool_defs,
+            tool_defs=tool_defs,
             thinking=chat_model.thinking,
         )
-        self.loaded = False
-        self.loading = False
-        self.images = []
 
     def on_mount(self) -> None:
         self.query_one("#prompt").focus()
@@ -177,7 +201,7 @@ class ChatContainer(Widget):
             response_chat_item.remove()
             input = self.query_one("#prompt", FlexibleInput)
             input.text = message
-        except ResponseError as e:
+        except (ResponseError, httpx.HTTPStatusError) as e:
             user_chat_item.remove()
             response_chat_item.remove()
             self.app.notify(
@@ -238,16 +262,9 @@ class ChatContainer(Widget):
             if tool_def["tool"] in self.chat_model.tools
         ]
 
-        # Recreate the Ollama client with updated parameters
-        self.ollama = OllamaLLM(
-            model=self.chat_model.model,
-            system=self.chat_model.system,
-            format=self.chat_model.format,
-            options=self.chat_model.parameters,
-            keep_alive=self.chat_model.keep_alive,
-            history=history,  # type: ignore
-            tool_defs=used_tool_defs,
-            thinking=self.chat_model.thinking,
+        # Recreate the LLM client with updated parameters
+        self.ollama = self._create_llm_client(
+            self.chat_model, history, used_tool_defs
         )
 
     @work
@@ -265,15 +282,8 @@ class ChatContainer(Widget):
     async def action_clear_chat(self) -> None:
         self.messages = []
         self.images = []
-        self.ollama = OllamaLLM(
-            model=self.ollama.model,
-            system=self.ollama.system,
-            format=self.ollama.format,  # type: ignore
-            options=self.chat_model.parameters,
-            keep_alive=self.ollama.keep_alive,
-            history=[],  # type: ignore
-            tool_defs=self.ollama.tool_defs,
-            thinking=self.chat_model.thinking,
+        self.ollama = self._create_llm_client(
+            self.chat_model, [], list(self.ollama.tool_defs),
         )
         msg_container = self.query_one("#messageContainer")
         for child in msg_container.children:

--- a/src/oterm/config.py
+++ b/src/oterm/config.py
@@ -17,6 +17,8 @@ class EnvConfig(BaseModel):
     OTERM_VERIFY_SSL: bool = True
     OTERM_DATA_DIR: Path = get_default_data_dir()
     OPEN_WEATHER_MAP_API_KEY: str = ""
+    MINIMAX_API_KEY: str = ""
+    MINIMAX_BASE_URL: str = "https://api.minimax.io/v1"
 
 
 envConfig = EnvConfig.model_validate(os.environ)

--- a/src/oterm/minimaxclient.py
+++ b/src/oterm/minimaxclient.py
@@ -1,0 +1,341 @@
+import inspect
+import json
+from collections.abc import AsyncGenerator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from oterm.config import envConfig
+from oterm.log import log
+from oterm.types import ToolCall
+
+
+@dataclass
+class MiniMaxModel:
+    """Compatible with ollama Model for UI usage."""
+
+    model: str
+    size: int = 0
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+
+@dataclass
+class MiniMaxModelInfo:
+    """Compatible with ollama ShowResponse for UI usage."""
+
+    name: str
+    parameters: str = ""
+    capabilities: list[str] = field(default_factory=list)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key == "system":
+            return ""
+        if key == "capabilities":
+            return self.capabilities
+        if key == "parameters":
+            return self.parameters
+        return default
+
+
+@dataclass
+class MiniMaxListResponse:
+    """Compatible with ollama ListResponse for UI usage."""
+
+    models: list[MiniMaxModel] = field(default_factory=list)
+
+
+MINIMAX_MODELS_INFO: list[dict[str, Any]] = [
+    {
+        "name": "MiniMax-M2.7",
+        "capabilities": ["tools", "thinking"],
+        "context_length": 1048576,
+    },
+    {
+        "name": "MiniMax-M2.7-highspeed",
+        "capabilities": ["tools", "thinking"],
+        "context_length": 1048576,
+    },
+    {
+        "name": "MiniMax-M2.5",
+        "capabilities": ["tools"],
+        "context_length": 204800,
+    },
+    {
+        "name": "MiniMax-M2.5-highspeed",
+        "capabilities": ["tools"],
+        "context_length": 204800,
+    },
+]
+
+
+class MiniMaxLLM:
+    def __init__(
+        self,
+        model: str = "MiniMax-M2.7",
+        system: str | None = None,
+        history: Sequence[Mapping[str, Any] | Any] = [],
+        format: str = "",
+        options: Any = None,
+        keep_alive: int = 5,
+        tool_defs: Sequence[ToolCall] = [],
+        thinking: bool = False,
+    ):
+        self.model = model
+        self.system = system
+        self.history: list[dict[str, Any]] = []
+        self.format = format
+        self.keep_alive = keep_alive
+        self.options = options
+        self.tool_defs = tool_defs
+        self.tools = self._convert_tools(tool_defs)
+        self.thinking = thinking
+
+        if system:
+            self.history.append({"role": "system", "content": system})
+
+        for msg in history:
+            self.history.append(self._to_dict(msg))
+
+    @staticmethod
+    def _to_dict(msg: Any) -> dict[str, Any]:
+        """Convert an ollama Message or dict to a plain dict."""
+        if isinstance(msg, dict):
+            return dict(msg)
+        return {"role": getattr(msg, "role", "user"), "content": getattr(msg, "content", "") or ""}
+
+    @staticmethod
+    def _convert_tools(tool_defs: Sequence[ToolCall]) -> list[dict[str, Any]]:
+        """Convert ollama tool definitions to OpenAI function-calling format."""
+        tools: list[dict[str, Any]] = []
+        for td in tool_defs:
+            tool = td["tool"]
+            if hasattr(tool, "model_dump"):
+                tool_dict = tool.model_dump()
+            else:
+                tool_dict = dict(tool)
+            tools.append(
+                {
+                    "type": "function",
+                    "function": tool_dict.get("function", tool_dict),
+                }
+            )
+        return tools
+
+    def _get_temperature(self, additional_options: Any = None) -> float | None:
+        """Extract and clamp temperature from options."""
+        temp = None
+        if self.options is not None:
+            if isinstance(self.options, dict):
+                temp = self.options.get("temperature")
+            elif hasattr(self.options, "temperature"):
+                temp = self.options.temperature
+
+        if additional_options is not None:
+            if isinstance(additional_options, dict):
+                t = additional_options.get("temperature")
+            elif hasattr(additional_options, "temperature"):
+                t = additional_options.temperature
+            else:
+                t = None
+            if t is not None:
+                temp = t
+
+        if temp is not None:
+            return max(0.0, min(float(temp), 1.0))
+        return None
+
+    async def stream(
+        self,
+        prompt: str = "",
+        images: list[Any] = [],
+        additional_options: Any = None,
+        tool_call_messages: list[dict[str, Any]] = [],
+    ) -> AsyncGenerator[tuple[str, str], Any]:
+        """Stream a chat response from the MiniMax API.
+
+        Yields (thought, text) tuples to stay compatible with OllamaLLM.
+        """
+        if prompt:
+            self.history.append({"role": "user", "content": prompt})
+
+        messages = self.history + tool_call_messages
+
+        body: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "stream": True,
+        }
+
+        temp = self._get_temperature(additional_options)
+        if temp is not None:
+            body["temperature"] = temp
+
+        if self.format == "json":
+            body["response_format"] = {"type": "json_object"}
+
+        if self.tools:
+            body["tools"] = self.tools
+
+        headers = {
+            "Authorization": f"Bearer {envConfig.MINIMAX_API_KEY}",
+            "Content-Type": "application/json",
+        }
+
+        raw_content = ""
+        thought = ""
+        text = ""
+        pending_tool_calls: list[dict[str, Any]] = []
+
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            async with client.stream(
+                "POST",
+                f"{envConfig.MINIMAX_BASE_URL}/chat/completions",
+                json=body,
+                headers=headers,
+            ) as response:
+                response.raise_for_status()
+
+                async for line in response.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    data = line[6:]
+                    if data.strip() == "[DONE]":
+                        break
+
+                    try:
+                        chunk = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+
+                    choices = chunk.get("choices", [])
+                    if not choices:
+                        continue
+
+                    delta = choices[0].get("delta", {})
+                    content = delta.get("content", "") or ""
+
+                    # Accumulate tool calls
+                    if delta.get("tool_calls"):
+                        for tc in delta["tool_calls"]:
+                            idx = tc.get("index", 0)
+                            while len(pending_tool_calls) <= idx:
+                                pending_tool_calls.append(
+                                    {"id": "", "function": {"name": "", "arguments": ""}}
+                                )
+                            if tc.get("id"):
+                                pending_tool_calls[idx]["id"] = tc["id"]
+                            func = tc.get("function", {})
+                            if func.get("name"):
+                                pending_tool_calls[idx]["function"]["name"] = func["name"]
+                            if func.get("arguments"):
+                                pending_tool_calls[idx]["function"]["arguments"] += func[
+                                    "arguments"
+                                ]
+
+                    if content:
+                        raw_content += content
+                        thought, text = self._parse_think_tags(raw_content)
+                        yield thought, text
+
+        # Handle tool calls after streaming completes
+        if pending_tool_calls:
+            tool_messages: list[dict[str, Any]] = [
+                {
+                    "role": "assistant",
+                    "content": text or None,
+                    "tool_calls": [
+                        {
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": tc["function"],
+                        }
+                        for tc in pending_tool_calls
+                    ],
+                }
+            ]
+
+            if thought:
+                tool_messages.insert(0, {"role": "assistant", "content": f"<think>{thought}</think>"})
+
+            for tc in pending_tool_calls:
+                tool_name = tc["function"]["name"]
+                try:
+                    tool_args = json.loads(tc["function"]["arguments"])
+                except json.JSONDecodeError:
+                    tool_args = {}
+
+                for tool_def in self.tool_defs:
+                    td_name = tool_def["tool"]
+                    if hasattr(td_name, "model_dump"):
+                        td_name = td_name.model_dump()
+                    if isinstance(td_name, dict):
+                        td_name = td_name.get("function", {}).get("name", "")
+                    else:
+                        td_name = ""
+
+                    if td_name == tool_name:
+                        tool_callable = tool_def["callable"]
+                        try:
+                            log.debug(f"Calling tool: {tool_name} with {tool_args}")
+                            if inspect.iscoroutinefunction(tool_callable):
+                                tool_response = await tool_callable(**tool_args)
+                            else:
+                                tool_response = tool_callable(**tool_args)
+
+                            log.debug(f"Tool response: {tool_response}")
+                            tool_messages.append(
+                                {
+                                    "role": "tool",
+                                    "content": str(tool_response),
+                                    "tool_call_id": tc["id"],
+                                }
+                            )
+                        except Exception as e:
+                            log.error(f"Error calling tool {tool_name}: {e}")
+                            return
+
+            async for thought_chunk, text_chunk in self.stream(
+                tool_call_messages=tool_messages,
+                additional_options=additional_options,
+            ):
+                yield thought_chunk, text_chunk
+                text = text_chunk
+                thought = thought_chunk
+
+        elif text:
+            self.history.append({"role": "assistant", "content": text})
+
+    @staticmethod
+    def _parse_think_tags(content: str) -> tuple[str, str]:
+        """Parse <think>...</think> tags from content, returning (thought, text)."""
+        if not content.startswith("<think>"):
+            return "", content
+
+        end_idx = content.find("</think>")
+        if end_idx == -1:
+            # Still inside thinking — all content is thought
+            return content[7:], ""
+
+        thought = content[7:end_idx]
+        text = content[end_idx + 8 :]
+        return thought, text
+
+    @staticmethod
+    def list() -> MiniMaxListResponse:
+        """Return available MiniMax models."""
+        models = [MiniMaxModel(model=m["name"]) for m in MINIMAX_MODELS_INFO]
+        return MiniMaxListResponse(models=models)
+
+    @staticmethod
+    def show(model: str) -> MiniMaxModelInfo:
+        """Return model details."""
+        for m in MINIMAX_MODELS_INFO:
+            if m["name"] == model:
+                return MiniMaxModelInfo(
+                    name=m["name"],
+                    capabilities=m.get("capabilities", []),
+                )
+        return MiniMaxModelInfo(name=model)

--- a/src/oterm/store/store.py
+++ b/src/oterm/store/store.py
@@ -34,6 +34,7 @@ class Store:
                         "id"            INTEGER,
                         "name"          TEXT,
                         "model"         TEXT NOT NULL,
+                        "provider"      TEXT DEFAULT "ollama",
                         "system"        TEXT,
                         "format"        TEXT,
                         "parameters"    TEXT DEFAULT "{}",
@@ -86,12 +87,13 @@ class Store:
             res = await connection.execute_insert(
                 """
                 INSERT OR REPLACE
-                INTO chat(id, name, model, system, format, parameters, keep_alive, tools, thinking)
-                VALUES(:id, :name, :model, :system, :format, :parameters, :keep_alive, :tools, :thinking) RETURNING id;""",
+                INTO chat(id, name, model, provider, system, format, parameters, keep_alive, tools, thinking)
+                VALUES(:id, :name, :model, :provider, :system, :format, :parameters, :keep_alive, :tools, :thinking) RETURNING id;""",
                 {
                     "id": chat_model.id,
                     "name": chat_model.name,
                     "model": chat_model.model,
+                    "provider": chat_model.provider,
                     "system": chat_model.system,
                     "format": chat_model.format,
                     "parameters": json.dumps(
@@ -121,6 +123,7 @@ class Store:
                 """
                 UPDATE chat
                 SET name = :name,
+                    provider = :provider,
                     system = :system,
                     format = :format,
                     parameters = :parameters,
@@ -132,6 +135,7 @@ class Store:
                 {
                     "id": chat_model.id,
                     "name": chat_model.name,
+                    "provider": chat_model.provider,
                     "system": chat_model.system,
                     "format": chat_model.format,
                     "parameters": json.dumps(
@@ -150,7 +154,7 @@ class Store:
         async with aiosqlite.connect(self.db_path) as connection:
             chats = await connection.execute_fetchall(
                 """
-                SELECT id, name, model, system, format, parameters, keep_alive, tools, thinking
+                SELECT id, name, model, provider, system, format, parameters, keep_alive, tools, thinking
                 FROM chat;
                 """
             )
@@ -160,6 +164,7 @@ class Store:
                     id=id,
                     name=name,
                     model=model,
+                    provider=provider or "ollama",
                     system=system,
                     format=format,
                     parameters=json.loads(parameters),
@@ -167,14 +172,14 @@ class Store:
                     tools=[Tool(**t) for t in json.loads(tools)],
                     thinking=thinking,
                 )
-                for id, name, model, system, format, parameters, keep_alive, tools, thinking in chats
+                for id, name, model, provider, system, format, parameters, keep_alive, tools, thinking in chats
             ]
 
     async def get_chat(self, id: int) -> ChatModel | None:
         async with aiosqlite.connect(self.db_path) as connection:
             chat = await connection.execute_fetchall(
                 """
-                SELECT id, name, model, system, format, parameters, keep_alive, tools, thinking
+                SELECT id, name, model, provider, system, format, parameters, keep_alive, tools, thinking
                 FROM chat
                 WHERE id = :id;
                 """,
@@ -186,6 +191,7 @@ class Store:
                     id,
                     name,
                     model,
+                    provider,
                     system,
                     format,
                     parameters,
@@ -197,6 +203,7 @@ class Store:
                     id=id,
                     name=name,
                     model=model,
+                    provider=provider or "ollama",
                     system=system,
                     format=format,
                     parameters=json.loads(parameters),

--- a/src/oterm/store/upgrades/__init__.py
+++ b/src/oterm/store/upgrades/__init__.py
@@ -11,6 +11,7 @@ from oterm.store.upgrades.v0_7_0 import upgrades as v0_7_0_upgrades
 from oterm.store.upgrades.v0_9_0 import upgrades as v0_9_0_upgrades
 from oterm.store.upgrades.v0_12_0 import upgrades as v0_12_0_upgrades
 from oterm.store.upgrades.v0_13_1 import upgrades as v0_13_1_upgrades
+from oterm.store.upgrades.v0_14_8 import upgrades as v0_14_8_upgrades
 
 upgrades = (
     v0_1_6_upgrades
@@ -26,4 +27,5 @@ upgrades = (
     + v0_9_0_upgrades
     + v0_12_0_upgrades
     + v0_13_1_upgrades
+    + v0_14_8_upgrades
 )

--- a/src/oterm/store/upgrades/v0_14_8.py
+++ b/src/oterm/store/upgrades/v0_14_8.py
@@ -1,0 +1,18 @@
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import aiosqlite
+
+
+async def add_provider_column(db_path: Path) -> None:
+    """Add provider column to chat table for multi-provider support."""
+    async with aiosqlite.connect(db_path) as connection:
+        await connection.execute(
+            "ALTER TABLE chat ADD COLUMN provider TEXT DEFAULT 'ollama'"
+        )
+        await connection.commit()
+
+
+upgrades: list[tuple[str, list[Callable[[Path], Awaitable[None]]]]] = [
+    ("0.14.8", [add_provider_column])
+]

--- a/src/oterm/types.py
+++ b/src/oterm/types.py
@@ -43,6 +43,7 @@ class ChatModel(BaseModel):
     id: int | None = None
     name: str = ""
     model: str = ""
+    provider: str = "ollama"
     system: str | None = None
     format: str = ""
     parameters: OtermOllamaOptions = Field(default_factory=OtermOllamaOptions)

--- a/tests/test_minimax_client.py
+++ b/tests/test_minimax_client.py
@@ -1,0 +1,415 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+from oterm.minimaxclient import (
+    MiniMaxLLM,
+    MiniMaxListResponse,
+    MiniMaxModel,
+    MiniMaxModelInfo,
+    MINIMAX_MODELS_INFO,
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def load_test_models():
+    """Override the conftest autouse fixture that requires Ollama."""
+    yield
+
+
+# ---------- Unit tests for helper types ----------
+
+
+class TestMiniMaxModel:
+    def test_model_attribute(self):
+        model = MiniMaxModel(model="MiniMax-M2.7")
+        assert model.model == "MiniMax-M2.7"
+
+    def test_size_default(self):
+        model = MiniMaxModel(model="MiniMax-M2.7")
+        assert model.size == 0
+
+    def test_getitem_size(self):
+        model = MiniMaxModel(model="MiniMax-M2.7", size=42)
+        assert model["size"] == 42
+
+
+class TestMiniMaxModelInfo:
+    def test_name(self):
+        info = MiniMaxModelInfo(name="MiniMax-M2.7", capabilities=["tools", "thinking"])
+        assert info.name == "MiniMax-M2.7"
+
+    def test_get_capabilities(self):
+        info = MiniMaxModelInfo(name="MiniMax-M2.7", capabilities=["tools", "thinking"])
+        assert info.get("capabilities") == ["tools", "thinking"]
+
+    def test_get_system_returns_empty(self):
+        info = MiniMaxModelInfo(name="MiniMax-M2.7")
+        assert info.get("system", "") == ""
+
+    def test_get_unknown_returns_default(self):
+        info = MiniMaxModelInfo(name="MiniMax-M2.7")
+        assert info.get("unknown_key", "fallback") == "fallback"
+
+
+class TestMiniMaxListResponse:
+    def test_list_response(self):
+        resp = MiniMaxListResponse(models=[MiniMaxModel(model="MiniMax-M2.7")])
+        assert len(resp.models) == 1
+        assert resp.models[0].model == "MiniMax-M2.7"
+
+
+# ---------- Unit tests for MiniMaxLLM static methods ----------
+
+
+class TestMiniMaxLLMList:
+    def test_list_returns_all_models(self):
+        response = MiniMaxLLM.list()
+        assert isinstance(response, MiniMaxListResponse)
+        assert len(response.models) == len(MINIMAX_MODELS_INFO)
+
+    def test_list_model_names(self):
+        response = MiniMaxLLM.list()
+        names = [m.model for m in response.models]
+        assert "MiniMax-M2.7" in names
+        assert "MiniMax-M2.5" in names
+        assert "MiniMax-M2.5-highspeed" in names
+        assert "MiniMax-M2.7-highspeed" in names
+
+
+class TestMiniMaxLLMShow:
+    def test_show_known_model(self):
+        info = MiniMaxLLM.show("MiniMax-M2.7")
+        assert isinstance(info, MiniMaxModelInfo)
+        assert info.name == "MiniMax-M2.7"
+        assert "tools" in info.get("capabilities", [])
+        assert "thinking" in info.get("capabilities", [])
+
+    def test_show_m25_model(self):
+        info = MiniMaxLLM.show("MiniMax-M2.5")
+        assert info.name == "MiniMax-M2.5"
+        assert "tools" in info.get("capabilities", [])
+        assert "thinking" not in info.get("capabilities", [])
+
+    def test_show_unknown_model(self):
+        info = MiniMaxLLM.show("nonexistent")
+        assert info.name == "nonexistent"
+        assert info.get("capabilities", []) == []
+
+
+# ---------- Unit tests for think-tag parsing ----------
+
+
+class TestParseThinkTags:
+    def test_no_think_tags(self):
+        thought, text = MiniMaxLLM._parse_think_tags("Hello, world!")
+        assert thought == ""
+        assert text == "Hello, world!"
+
+    def test_complete_think_tags(self):
+        content = "<think>reasoning here</think>actual response"
+        thought, text = MiniMaxLLM._parse_think_tags(content)
+        assert thought == "reasoning here"
+        assert text == "actual response"
+
+    def test_incomplete_think_tag(self):
+        content = "<think>still thinking..."
+        thought, text = MiniMaxLLM._parse_think_tags(content)
+        assert thought == "still thinking..."
+        assert text == ""
+
+    def test_empty_think_tags(self):
+        content = "<think></think>response only"
+        thought, text = MiniMaxLLM._parse_think_tags(content)
+        assert thought == ""
+        assert text == "response only"
+
+
+# ---------- Unit tests for temperature clamping ----------
+
+
+class TestTemperatureClamping:
+    def test_temperature_from_dict(self):
+        llm = MiniMaxLLM(options={"temperature": 0.7})
+        assert llm._get_temperature() == 0.7
+
+    def test_temperature_clamped_high(self):
+        llm = MiniMaxLLM(options={"temperature": 2.0})
+        assert llm._get_temperature() == 1.0
+
+    def test_temperature_clamped_low(self):
+        llm = MiniMaxLLM(options={"temperature": -1.0})
+        assert llm._get_temperature() == 0.0
+
+    def test_temperature_none(self):
+        llm = MiniMaxLLM(options={})
+        assert llm._get_temperature() is None
+
+    def test_temperature_from_options_object(self):
+        from ollama import Options
+
+        llm = MiniMaxLLM(options=Options(temperature=0.5))
+        assert llm._get_temperature() == 0.5
+
+
+# ---------- Unit tests for initialization ----------
+
+
+class TestMiniMaxLLMInit:
+    def test_default_model(self):
+        llm = MiniMaxLLM()
+        assert llm.model == "MiniMax-M2.7"
+
+    def test_system_prompt_in_history(self):
+        llm = MiniMaxLLM(system="You are helpful.")
+        assert llm.history[0]["role"] == "system"
+        assert llm.history[0]["content"] == "You are helpful."
+
+    def test_history_from_dicts(self):
+        history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        llm = MiniMaxLLM(history=history)
+        assert len(llm.history) == 2
+        assert llm.history[0]["content"] == "Hello"
+
+    def test_history_from_ollama_messages(self):
+        from ollama import Message
+
+        msgs = [
+            Message(role="user", content="Hello"),
+            Message(role="assistant", content="Hi!"),
+        ]
+        llm = MiniMaxLLM(history=msgs)
+        assert len(llm.history) == 2
+        assert llm.history[0]["role"] == "user"
+        assert llm.history[1]["content"] == "Hi!"
+
+    def test_tool_defs_conversion(self):
+        from ollama import Tool
+
+        tool = Tool(
+            type="function",
+            function=Tool.Function(
+                name="get_time",
+                description="Get current time",
+                parameters=Tool.Function.Parameters(
+                    type="object",
+                    properties={
+                        "timezone": Tool.Function.Parameters.Property(
+                            type="string", description="Timezone"
+                        )
+                    },
+                ),
+            ),
+        )
+        llm = MiniMaxLLM(tool_defs=[{"tool": tool, "callable": lambda: "now"}])
+        assert len(llm.tools) == 1
+        assert llm.tools[0]["type"] == "function"
+
+
+# ---------- Unit tests for streaming (mocked HTTP) ----------
+
+
+def _make_sse_lines(chunks: list[dict]) -> list[str]:
+    """Helper to create SSE lines from chunk dicts."""
+    lines = []
+    for chunk in chunks:
+        lines.append(f"data: {json.dumps(chunk)}")
+    lines.append("data: [DONE]")
+    return lines
+
+
+async def _async_iter(items):
+    """Convert a list to an async iterator."""
+    for item in items:
+        yield item
+
+
+def _mock_streaming_client(sse_lines: list[str]):
+    """Create a properly mocked httpx AsyncClient for streaming."""
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_lines = MagicMock(return_value=_async_iter(sse_lines))
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+class TestMiniMaxLLMStream:
+    @pytest.mark.asyncio
+    async def test_stream_basic(self):
+        chunks = [
+            {
+                "choices": [
+                    {"delta": {"content": "Hello"}, "index": 0, "finish_reason": None}
+                ]
+            },
+            {
+                "choices": [
+                    {"delta": {"content": " world"}, "index": 0, "finish_reason": "stop"}
+                ]
+            },
+        ]
+        mock_client = _mock_streaming_client(_make_sse_lines(chunks))
+
+        with patch("oterm.minimaxclient.httpx.AsyncClient", return_value=mock_client):
+            with patch("oterm.minimaxclient.envConfig") as mock_config:
+                mock_config.MINIMAX_API_KEY = "test-key"
+                mock_config.MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+                llm = MiniMaxLLM(model="MiniMax-M2.7")
+                result_text = ""
+                async for thought, text in llm.stream("Hi"):
+                    result_text = text
+
+                assert "Hello world" in result_text
+                assert len(llm.history) >= 2  # user + assistant
+
+    @pytest.mark.asyncio
+    async def test_stream_with_thinking(self):
+        chunks = [
+            {
+                "choices": [
+                    {
+                        "delta": {"content": "<think>Let me think</think>The answer"},
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        ]
+        mock_client = _mock_streaming_client(_make_sse_lines(chunks))
+
+        with patch("oterm.minimaxclient.httpx.AsyncClient", return_value=mock_client):
+            with patch("oterm.minimaxclient.envConfig") as mock_config:
+                mock_config.MINIMAX_API_KEY = "test-key"
+                mock_config.MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+                llm = MiniMaxLLM(model="MiniMax-M2.7", thinking=True)
+                result_thought = ""
+                result_text = ""
+                async for thought, text in llm.stream("What is 1+1?"):
+                    result_thought = thought
+                    result_text = text
+
+                assert result_thought == "Let me think"
+                assert result_text == "The answer"
+
+    @pytest.mark.asyncio
+    async def test_stream_json_format(self):
+        chunks = [
+            {
+                "choices": [
+                    {
+                        "delta": {"content": '{"answer": 42}'},
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        ]
+        mock_client = _mock_streaming_client(_make_sse_lines(chunks))
+
+        with patch("oterm.minimaxclient.httpx.AsyncClient", return_value=mock_client):
+            with patch("oterm.minimaxclient.envConfig") as mock_config:
+                mock_config.MINIMAX_API_KEY = "test-key"
+                mock_config.MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+                llm = MiniMaxLLM(model="MiniMax-M2.7", format="json")
+                result_text = ""
+                async for _, text in llm.stream("Give me JSON"):
+                    result_text = text
+
+                # Verify JSON format was requested
+                call_args = mock_client.stream.call_args
+                body = call_args.kwargs.get("json", {})
+                assert body.get("response_format") == {"type": "json_object"}
+
+    @pytest.mark.asyncio
+    async def test_stream_temperature_clamping(self):
+        chunks = [
+            {
+                "choices": [
+                    {
+                        "delta": {"content": "ok"},
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        ]
+        mock_client = _mock_streaming_client(_make_sse_lines(chunks))
+
+        with patch("oterm.minimaxclient.httpx.AsyncClient", return_value=mock_client):
+            with patch("oterm.minimaxclient.envConfig") as mock_config:
+                mock_config.MINIMAX_API_KEY = "test-key"
+                mock_config.MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+                llm = MiniMaxLLM(
+                    model="MiniMax-M2.7", options={"temperature": 5.0}
+                )
+                async for _, _ in llm.stream("test"):
+                    pass
+
+                call_args = mock_client.stream.call_args
+                body = call_args.kwargs.get("json", {})
+                assert body.get("temperature") == 1.0
+
+
+# ---------- Integration tests (require MINIMAX_API_KEY) ----------
+
+
+class TestMiniMaxIntegration:
+    @pytest.fixture
+    def api_key(self):
+        import os
+
+        key = os.environ.get("MINIMAX_API_KEY", "")
+        if not key:
+            pytest.skip("MINIMAX_API_KEY not set")
+        return key
+
+    @pytest.mark.asyncio
+    async def test_live_stream(self, api_key):
+        llm = MiniMaxLLM(
+            model="MiniMax-M2.5-highspeed",
+            options={"temperature": 0.0},
+        )
+        result = ""
+        async for _, text in llm.stream("What is 2+2? Answer with just the number."):
+            result = text
+        assert "4" in result
+
+    @pytest.mark.asyncio
+    async def test_live_conversation_context(self, api_key):
+        llm = MiniMaxLLM(
+            model="MiniMax-M2.5-highspeed",
+            options={"temperature": 0.0},
+        )
+        async for _, _ in llm.stream("My name is oterm. Remember it."):
+            pass
+        result = ""
+        async for _, text in llm.stream("What is my name?"):
+            result = text
+        assert "oterm" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_live_system_prompt(self, api_key):
+        llm = MiniMaxLLM(
+            model="MiniMax-M2.5-highspeed",
+            system="You are a pirate. Always say 'Arrr' in your response.",
+            options={"temperature": 0.0},
+        )
+        result = ""
+        async for _, text in llm.stream("Hello"):
+            result = text
+        assert "arrr" in result.lower() or "arr" in result.lower()


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimaxi.com) as an alternative cloud LLM provider alongside Ollama, enabling users to chat with MiniMax-M2.7, M2.7-highspeed, M2.5 and M2.5-highspeed models directly from the terminal.

### Changes

- **`minimaxclient.py`**: New `MiniMaxLLM` client with SSE streaming via `httpx`, tool call support, `<think>` tag parsing for thinking mode, and temperature clamping to \[0, 1.0\]
- **`chat_edit.py`**: Provider selector (`RadioSet`: Ollama / MiniMax) in the model selection screen — MiniMax option is automatically disabled when `MINIMAX_API_KEY` is not set
- **`config.py`**: `MINIMAX_API_KEY` and `MINIMAX_BASE_URL` environment variables
- **`types.py`**: `provider` field on `ChatModel` (defaults to `"ollama"` for backward compatibility)
- **`store.py` + `v0_14_8.py`**: Database migration to persist provider per chat session
- **`chat.py`**: `_create_llm_client()` factory that routes to the correct client based on provider, plus `httpx.HTTPStatusError` error handling
- **31 unit tests + 3 integration tests** covering model listing, think-tag parsing, temperature clamping, streaming, and live API calls

### Configuration

```bash
export MINIMAX_API_KEY="your-key-here"
# Optional: export MINIMAX_BASE_URL="https://api.minimax.io/v1"
oterm
```

When `MINIMAX_API_KEY` is set, a provider toggle appears in the chat creation screen.

### No breaking changes

- Existing Ollama-only workflows are unaffected (provider defaults to `"ollama"`)
- No new Python dependencies (uses `httpx` already available via `ollama`)
- Database auto-migrates with `ALTER TABLE chat ADD COLUMN provider`

## Test plan

- [x] 31 unit tests pass (model types, think-tag parsing, temperature clamping, streaming with mocked HTTP)
- [x] 3 integration tests pass against live MiniMax API
- [ ] Manual testing: create MiniMax chat, stream response, verify thinking mode, verify tool calls
- [ ] Verify existing Ollama tests still pass when Ollama server is available