### PR TITLE
Support Ollama image generation as a built-in tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Built-in `generate_image` tool.** Delegates to Ollama's `/api/generate` with image-generation models (`x/z-image-turbo`, `x/flux2-klein`, …). Configure the default model with `OTERM_OLLAMA_IMAGE_MODEL` or override per call via the tool's `model` argument.
+
+## [0.17.0] - 2026-05-03
+
+### Added
+
 - **Render assistant-emitted images inline.** When a model returns a `FilePart` during streaming, the image renders between the thinking section and the response, persists alongside the assistant message in the chat store, and reappears on chat reload. Click an image to save it to `$OTERM_DATA_DIR/downloads/`. Works with Google Gemini image-preview models out of the box.
 - **New `openai-responses` provider.** Routes through pydantic-ai's `OpenAIResponsesModel` and enables the `ImageGenerationTool` builtin on every Agent built for it. Pick "OpenAI Responses" in the chat-edit modal, choose a Responses-compatible model (e.g. `gpt-5.4`), and image generation is implicit — no per-chat toggle. Reuses `OPENAI_API_KEY` and the existing OpenAI model lister.
 - **Save logs from the log viewer.** Press `s` in the logs modal to write the current buffer to a timestamped `oterm-logs-<ts>.txt` under `$OTERM_DATA_DIR/logs/`. Useful for debugging MCP servers. [robbyt]

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -57,6 +57,7 @@ The following tools are built-in to `oterm` and available by default:
 * `think` - provides the model with a way to think about a question before answering it. This is useful for complex questions that require reasoning. Use it for adding a "thinking" step to the model's response.
 * `date_time` - provides the current date and time in ISO format.
 * `shell` - allows you to run shell commands and use the output as input to the model. Obviously this can be dangerous, so use with caution.
+* `generate_image` - generates an image from a text prompt using an Ollama image-generation model (e.g. `x/z-image-turbo`, `x/flux2-klein`). The default model is `x/z-image-turbo`; override it for a single call via the tool's `model` argument or globally via the `OTERM_OLLAMA_IMAGE_MODEL` environment variable. The image renders inline in the chat. Requires an Ollama server with an image-capable model installed; the host LLM (any provider) writes the prompt and calls the tool.
 
 ### Tool calls in the chat
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pydantic==2.13.3",
     "pydantic-ai-slim[openai,anthropic,google,vertexai,groq,mistral,cohere,bedrock,huggingface,mcp,fastmcp,logfire]==1.93.0",
     "python-dotenv==1.2.2",
+    "python-multipart>=0.0.27",
     "textual==8.2.4",
     "textual-image==0.12.0",
     "textual-speedups==0.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ dependencies = [
     "aiosql==15.0",
     "aiosqlite==0.22.1",
     "fastmcp==3.2.4",
-    "ollama==0.6.1",
+    "ollama==0.6.2",
     "packaging==26.2",
     "pillow==12.2.0",
     "pydantic==2.13.3",
-    "pydantic-ai-slim[openai,anthropic,google,vertexai,groq,mistral,cohere,bedrock,huggingface,mcp,fastmcp,logfire]==1.87.0",
+    "pydantic-ai-slim[openai,anthropic,google,vertexai,groq,mistral,cohere,bedrock,huggingface,mcp,fastmcp,logfire]==1.93.0",
     "python-dotenv==1.2.2",
     "textual==8.2.4",
     "textual-image==0.12.0",
@@ -119,6 +119,7 @@ python-version = "3.13"
 think = "oterm.tools.think:think"
 date_time = "oterm.tools.date_time:date_time"
 shell = "oterm.tools.shell:shell"
+generate_image = "oterm.tools.ollama_image:generate_image"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -30,6 +30,7 @@ from pydantic_ai.messages import (
     FilePart,
     FunctionToolResultEvent,
     ModelMessage,
+    RetryPromptPart,
     ThinkingPart,
     ToolCallPart,
     ToolReturnPart,
@@ -60,6 +61,7 @@ from oterm.app.prompt_history import PromptHistory
 from oterm.app.widgets.image import ImageAdded
 from oterm.app.widgets.prompt import IMAGE_TOKEN_RE, FlexibleInput, PostableTextArea
 from oterm.config import envConfig
+from oterm.log import log
 from oterm.store.store import Store
 from oterm.tools import builtin_tools
 from oterm.tools.mcp.setup import mcp_servers, mcp_tool_meta
@@ -260,7 +262,8 @@ class ChatContainer(Widget):
         | ToolCallPart
         | BuiltinToolCallPart
         | ToolReturnPart
-        | BuiltinToolReturnPart,
+        | BuiltinToolReturnPart
+        | RetryPromptPart,
         Any,
     ]:
         if self.agent is None:
@@ -315,10 +318,16 @@ class ChatContainer(Widget):
                 elif Agent.is_call_tools_node(node):
                     async with node.stream(run.ctx) as tools_stream:
                         async for event in tools_stream:
-                            if isinstance(
-                                event, FunctionToolResultEvent
-                            ) and isinstance(event.result, ToolReturnPart):
-                                yield event.result
+                            if not isinstance(event, FunctionToolResultEvent):
+                                continue
+                            if isinstance(event.part, ToolReturnPart):
+                                yield event.part
+                            elif isinstance(event.part, RetryPromptPart):
+                                log.error(
+                                    f"Tool {event.part.tool_name!r} failed: "
+                                    f"{event.part.model_response()}"
+                                )
+                                yield event.part
             if run.result is not None:  # pragma: no branch
                 self.pydantic_history = list(run.result.all_messages())
                 self._stream_usage = run.result.usage()
@@ -399,6 +408,11 @@ class ChatContainer(Widget):
                                 assistant_images.append(
                                     base64.b64encode(item.data).decode()
                                 )
+                    case RetryPromptPart():
+                        response_chat_item.update_tool_result(
+                            piece.tool_call_id,
+                            f"error: {piece.model_response()}",
+                        )
                     case FilePart(content=BinaryImage(data=data)):
                         await response_chat_item.add_image(data)
                         assistant_images.append(base64.b64encode(data).decode())

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -322,7 +322,9 @@ class ChatContainer(Widget):
                                 continue
                             if isinstance(event.part, ToolReturnPart):
                                 yield event.part
-                            elif isinstance(event.part, RetryPromptPart):
+                            elif isinstance(  # pragma: no branch
+                                event.part, RetryPromptPart
+                            ):
                                 log.error(
                                     f"Tool {event.part.tool_name!r} failed: "
                                     f"{event.part.model_response()}"

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -388,6 +388,17 @@ class ChatContainer(Widget):
                         response_chat_item.update_tool_result(
                             piece.tool_call_id, piece.content
                         )
+                        items = (
+                            piece.content
+                            if isinstance(piece.content, list)
+                            else [piece.content]
+                        )
+                        for item in items:
+                            if isinstance(item, BinaryImage):
+                                await response_chat_item.add_image(item.data)
+                                assistant_images.append(
+                                    base64.b64encode(item.data).decode()
+                                )
                     case FilePart(content=BinaryImage(data=data)):
                         await response_chat_item.add_image(data)
                         assistant_images.append(base64.b64encode(data).decode())

--- a/src/oterm/config.py
+++ b/src/oterm/config.py
@@ -17,6 +17,7 @@ class EnvConfig(BaseModel):
     OLLAMA_API_KEY: str | None = None
     OTERM_VERIFY_SSL: bool = True
     OTERM_DATA_DIR: Path = get_default_data_dir()
+    OTERM_OLLAMA_IMAGE_MODEL: str = "x/z-image-turbo"
 
 
 envConfig = EnvConfig.model_validate(os.environ)

--- a/src/oterm/tools/ollama_image.py
+++ b/src/oterm/tools/ollama_image.py
@@ -1,0 +1,28 @@
+import base64
+
+from ollama import AsyncClient
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import BinaryImage
+
+from oterm.config import envConfig
+from oterm.providers.ollama import ollama_client_host
+
+
+async def generate_image(prompt: str, model: str | None = None) -> BinaryImage:
+    """Generate an image from a text prompt using an Ollama image-generation model.
+
+    Use this when the user asks to create, draw, render, or visualize an image.
+
+    Args:
+        prompt: A descriptive prompt for the image to generate.
+        model: Optional Ollama image model name. Defaults to OTERM_OLLAMA_IMAGE_MODEL.
+    """
+    chosen = model or envConfig.OTERM_OLLAMA_IMAGE_MODEL
+    client = AsyncClient(host=ollama_client_host(), verify=envConfig.OTERM_VERIFY_SSL)
+    response = await client.generate(model=chosen, prompt=prompt)
+    if not response.image:
+        raise ModelRetry(
+            f"Model {chosen!r} did not return an image. "
+            "Pick an Ollama image-generation model (e.g. 'x/z-image-turbo')."
+        )
+    return BinaryImage(data=base64.b64decode(response.image), media_type="image/png")

--- a/src/oterm/tools/ollama_image.py
+++ b/src/oterm/tools/ollama_image.py
@@ -1,10 +1,11 @@
 import base64
 
-from ollama import AsyncClient
+from ollama import AsyncClient, RequestError, ResponseError
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import BinaryImage
 
 from oterm.config import envConfig
+from oterm.log import log
 from oterm.providers.ollama import ollama_client_host
 
 
@@ -19,8 +20,28 @@ async def generate_image(prompt: str, model: str | None = None) -> BinaryImage:
     """
     chosen = model or envConfig.OTERM_OLLAMA_IMAGE_MODEL
     client = AsyncClient(host=ollama_client_host(), verify=envConfig.OTERM_VERIFY_SSL)
-    response = await client.generate(model=chosen, prompt=prompt)
+    try:
+        response = await client.generate(model=chosen, prompt=prompt)
+    except ResponseError as exc:
+        log.error(
+            f"Ollama refused generate_image (model={chosen!r}, "
+            f"status={exc.status_code}): {exc.error}"
+        )
+        raise ModelRetry(
+            f"Ollama returned an error for model {chosen!r}: {exc.error}"
+        ) from exc
+    except RequestError as exc:
+        log.error(f"Ollama request error for generate_image (model={chosen!r}): {exc}")
+        raise ModelRetry(f"Could not reach Ollama for model {chosen!r}: {exc}") from exc
+    except Exception as exc:  # pragma: no cover
+        log.error(f"generate_image failed (model={chosen!r}): {exc!r}")
+        raise
+
     if not response.image:
+        log.error(
+            f"generate_image got no image bytes from Ollama (model={chosen!r}, "
+            f"done={response.done}, response_text={response.response!r})"
+        )
         raise ModelRetry(
             f"Model {chosen!r} did not return an image. "
             "Pick an Ollama image-generation model (e.g. 'x/z-image-turbo')."

--- a/tests/tools/test_ollama_image.py
+++ b/tests/tools/test_ollama_image.py
@@ -1,12 +1,13 @@
 import base64
 
 import pytest
-from ollama import AsyncClient
+from ollama import AsyncClient, RequestError, ResponseError
 from ollama._types import GenerateResponse
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import BinaryImage
 
 from oterm.config import envConfig
+from oterm.log import log_lines
 from oterm.tools.ollama_image import generate_image
 
 
@@ -14,6 +15,13 @@ def _patch_generate(monkeypatch, response: GenerateResponse, capture: dict):
     async def fake_generate(self, **kwargs):
         capture.update(kwargs)
         return response
+
+    monkeypatch.setattr(AsyncClient, "generate", fake_generate)
+
+
+def _patch_generate_raises(monkeypatch, exc: Exception):
+    async def fake_generate(self, **kwargs):
+        raise exc
 
     monkeypatch.setattr(AsyncClient, "generate", fake_generate)
 
@@ -36,12 +44,11 @@ class TestGenerateImage:
         assert capture["model"] == envConfig.OTERM_OLLAMA_IMAGE_MODEL
 
     async def test_model_argument_overrides_default(self, monkeypatch):
-        png = b"\x89PNG\r\n\x1a\nbytes"
         capture: dict = {}
         _patch_generate(
             monkeypatch,
             GenerateResponse(
-                response="", done=True, image=base64.b64encode(png).decode()
+                response="", done=True, image=base64.b64encode(b"x").decode()
             ),
             capture,
         )
@@ -50,36 +57,36 @@ class TestGenerateImage:
 
         assert capture["model"] == "x/flux2-klein"
 
-    async def test_env_var_changes_default_model(self, monkeypatch):
-        png = b"bytes"
-        capture: dict = {}
+    async def test_missing_image_logs_and_raises_model_retry(self, monkeypatch):
         _patch_generate(
             monkeypatch,
-            GenerateResponse(
-                response="", done=True, image=base64.b64encode(png).decode()
-            ),
-            capture,
+            GenerateResponse(response="hi", done=True, image=None),
+            {},
         )
-        monkeypatch.setattr(envConfig, "OTERM_OLLAMA_IMAGE_MODEL", "x/flux2-klein")
-
-        await generate_image(prompt="cat")
-
-        assert capture["model"] == "x/flux2-klein"
-
-    async def test_missing_image_raises_model_retry(self, monkeypatch):
-        capture: dict = {}
-        _patch_generate(
-            monkeypatch, GenerateResponse(response="", done=True, image=None), capture
-        )
+        log_lines.clear()
 
         with pytest.raises(ModelRetry, match="did not return an image"):
             await generate_image(prompt="cat", model="qwen3")
 
-    async def test_empty_image_raises_model_retry(self, monkeypatch):
-        capture: dict = {}
-        _patch_generate(
-            monkeypatch, GenerateResponse(response="", done=True, image=""), capture
-        )
+        messages = [m for _, m in log_lines]
+        assert any("qwen3" in m and "no image" in m.lower() for m in messages)
 
-        with pytest.raises(ModelRetry, match="qwen3"):
-            await generate_image(prompt="cat", model="qwen3")
+    async def test_response_error_is_logged_and_re_raised_as_retry(self, monkeypatch):
+        _patch_generate_raises(monkeypatch, ResponseError("model not found", 404))
+        log_lines.clear()
+
+        with pytest.raises(ModelRetry, match="model not found"):
+            await generate_image(prompt="cat", model="bogus")
+
+        messages = [m for _, m in log_lines]
+        assert any("bogus" in m and "404" in m for m in messages)
+
+    async def test_request_error_is_logged_and_re_raised_as_retry(self, monkeypatch):
+        _patch_generate_raises(monkeypatch, RequestError("connection refused"))
+        log_lines.clear()
+
+        with pytest.raises(ModelRetry, match="Could not reach Ollama"):
+            await generate_image(prompt="cat", model="x/z-image-turbo")
+
+        messages = [m for _, m in log_lines]
+        assert any("connection refused" in m for m in messages)

--- a/tests/tools/test_ollama_image.py
+++ b/tests/tools/test_ollama_image.py
@@ -1,0 +1,85 @@
+import base64
+
+import pytest
+from ollama import AsyncClient
+from ollama._types import GenerateResponse
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import BinaryImage
+
+from oterm.config import envConfig
+from oterm.tools.ollama_image import generate_image
+
+
+def _patch_generate(monkeypatch, response: GenerateResponse, capture: dict):
+    async def fake_generate(self, **kwargs):
+        capture.update(kwargs)
+        return response
+
+    monkeypatch.setattr(AsyncClient, "generate", fake_generate)
+
+
+class TestGenerateImage:
+    async def test_returns_binary_image_with_decoded_bytes(self, monkeypatch):
+        png = b"\x89PNG\r\n\x1a\nfake-bytes"
+        b64 = base64.b64encode(png).decode()
+        capture: dict = {}
+        _patch_generate(
+            monkeypatch, GenerateResponse(response="", done=True, image=b64), capture
+        )
+
+        result = await generate_image(prompt="a red square")
+
+        assert isinstance(result, BinaryImage)
+        assert result.data == png
+        assert result.media_type == "image/png"
+        assert capture["prompt"] == "a red square"
+        assert capture["model"] == envConfig.OTERM_OLLAMA_IMAGE_MODEL
+
+    async def test_model_argument_overrides_default(self, monkeypatch):
+        png = b"\x89PNG\r\n\x1a\nbytes"
+        capture: dict = {}
+        _patch_generate(
+            monkeypatch,
+            GenerateResponse(
+                response="", done=True, image=base64.b64encode(png).decode()
+            ),
+            capture,
+        )
+
+        await generate_image(prompt="cat", model="x/flux2-klein")
+
+        assert capture["model"] == "x/flux2-klein"
+
+    async def test_env_var_changes_default_model(self, monkeypatch):
+        png = b"bytes"
+        capture: dict = {}
+        _patch_generate(
+            monkeypatch,
+            GenerateResponse(
+                response="", done=True, image=base64.b64encode(png).decode()
+            ),
+            capture,
+        )
+        monkeypatch.setattr(envConfig, "OTERM_OLLAMA_IMAGE_MODEL", "x/flux2-klein")
+
+        await generate_image(prompt="cat")
+
+        assert capture["model"] == "x/flux2-klein"
+
+    async def test_missing_image_raises_model_retry(self, monkeypatch):
+        capture: dict = {}
+        _patch_generate(
+            monkeypatch, GenerateResponse(response="", done=True, image=None), capture
+        )
+
+        with pytest.raises(ModelRetry, match="did not return an image"):
+            await generate_image(prompt="cat", model="qwen3")
+
+    async def test_empty_image_raises_model_retry(self, monkeypatch):
+        capture: dict = {}
+        _patch_generate(
+            monkeypatch, GenerateResponse(response="", done=True, image=""), capture
+        )
+
+        with pytest.raises(ModelRetry, match="qwen3"):
+            await generate_image(prompt="cat", model="qwen3")

--- a/tests/widgets/test_chat_container.py
+++ b/tests/widgets/test_chat_container.py
@@ -1459,6 +1459,74 @@ class TestThinkingViaResponseTask:
             assert list(assistant.query(ImageWidget)) == []
             assert container.messages[-1].images == []
 
+    async def test_tool_returning_binary_image_renders_inline(self, store, chat_model):
+        """A tool returning `BinaryImage` mounts an Image widget and persists."""
+        from io import BytesIO
+
+        from PIL import Image as PILImage
+        from pydantic_ai import Tool
+        from pydantic_ai.messages import BinaryImage
+        from pydantic_ai.models.function import DeltaToolCall
+        from textual_image.widget import Image as ImageWidget
+
+        buf = BytesIO()
+        PILImage.new("RGB", (4, 4), "green").save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+
+        chat_id = await store.save_chat(chat_model)
+        chat_model.id = chat_id
+
+        def make_image(prompt: str) -> BinaryImage:
+            return BinaryImage(data=png_bytes, media_type="image/png")
+
+        async def stream_fn(
+            messages: list[ModelMessage], info: AgentInfo
+        ) -> AsyncIterator[str | dict[int, DeltaToolCall]]:
+            already_called = any(
+                getattr(m, "parts", None)
+                and any(getattr(p, "part_kind", "") == "tool-return" for p in m.parts)
+                for m in messages
+            )
+            if already_called:
+                yield "done"
+                return
+            yield {
+                0: DeltaToolCall(
+                    name="make_image",
+                    json_args='{"prompt": "a square"}',
+                    tool_call_id="tc-img",
+                )
+            }
+
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            container.agent = Agent(
+                FunctionModel(stream_function=stream_fn), tools=[Tool(make_image)]
+            )
+
+            prompt = app.query_one(FlexibleInput)
+            prompt.text = "draw"
+            await pilot.press("enter")
+            await wait_until(pilot, lambda: len(container.messages) == 2)
+
+            assistant = list(container.query(ChatItem))[-1]
+            images = list(assistant.query(ImageWidget))
+            assert len(images) == 1
+            assert images[0].image is not None
+
+            tool_items = list(assistant.query(ToolCallItem))
+            assert len(tool_items) == 1
+            assert tool_items[0].tool_name == "make_image"
+            assert tool_items[0].result is not None
+
+            assistant_row = container.messages[-1]
+            assert len(assistant_row.images) == 1
+            assert base64.b64decode(assistant_row.images[0]) == png_bytes
+            stored = await store.get_messages(chat_id)
+            assistant_rows = [m for m in stored if m.role == "assistant"]
+            assert len(assistant_rows[0].images) == 1
+
     async def test_persisted_assistant_image_renders_on_load(self, store, chat_model):
         from io import BytesIO
 

--- a/tests/widgets/test_chat_container.py
+++ b/tests/widgets/test_chat_container.py
@@ -1459,6 +1459,63 @@ class TestThinkingViaResponseTask:
             assert list(assistant.query(ImageWidget)) == []
             assert container.messages[-1].images == []
 
+    async def test_failing_tool_logs_and_shows_error_in_call_widget(
+        self, store, chat_model
+    ):
+        """A tool raising `ModelRetry` is logged and rendered as `error: …`."""
+        from pydantic_ai import Tool
+        from pydantic_ai.exceptions import ModelRetry
+        from pydantic_ai.models.function import DeltaToolCall
+
+        from oterm.log import log_lines
+
+        chat_id = await store.save_chat(chat_model)
+        chat_model.id = chat_id
+
+        def boom(s: str) -> str:
+            raise ModelRetry("kaboom")
+
+        async def stream_fn(
+            messages: list[ModelMessage], info: AgentInfo
+        ) -> AsyncIterator[str | dict[int, DeltaToolCall]]:
+            already_retried = any(
+                getattr(m, "parts", None)
+                and any(getattr(p, "part_kind", "") == "retry-prompt" for p in m.parts)
+                for m in messages
+            )
+            if already_retried:
+                yield "gave up"
+                return
+            yield {
+                0: DeltaToolCall(
+                    name="boom", json_args='{"s": "x"}', tool_call_id="tc-b"
+                )
+            }
+
+        log_lines.clear()
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            container.agent = Agent(
+                FunctionModel(stream_function=stream_fn), tools=[Tool(boom)]
+            )
+
+            prompt = app.query_one(FlexibleInput)
+            prompt.text = "go"
+            await pilot.press("enter")
+            await wait_until(pilot, lambda: len(container.messages) == 2)
+
+            assistant = list(container.query(ChatItem))[-1]
+            tool_items = list(assistant.query(ToolCallItem))
+            assert len(tool_items) == 1
+            assert tool_items[0].tool_name == "boom"
+            assert isinstance(tool_items[0].result, str)
+            assert tool_items[0].result.startswith("error:")
+            assert "kaboom" in tool_items[0].result
+
+            messages = [m for _, m in log_lines]
+            assert any("'boom' failed" in m and "kaboom" in m for m in messages)
+
     async def test_tool_returning_binary_image_renders_inline(self, store, chat_model):
         """A tool returning `BinaryImage` mounts an Image widget and persists."""
         from io import BytesIO

--- a/uv.lock
+++ b/uv.lock
@@ -980,6 +980,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/6f/2adb571fda448d4afd2466e1cef2963fefdc6b37847da05249983e415f17/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c", size = 3281842, upload-time = "2026-04-24T14:37:20.833Z" },
     { url = "https://files.pythonhosted.org/packages/17/07/4bad2e96c4c6bae40253be2573cc09c1e5b9ccf821e1ff74e0d33b64bf90/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f", size = 450903, upload-time = "2026-04-24T14:37:23.059Z" },
     { url = "https://files.pythonhosted.org/packages/5b/b7/180f67ba9a46ba23a1ff6432f48d3087d4f2048579ecc262b00426cb1c63/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a", size = 391076, upload-time = "2026-04-24T14:37:24.756Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/18f60329b627d2118a4a2b19e8741fbd807d60bf0470554e1bbfb7f1bca3/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b", size = 1055430, upload-time = "2026-05-09T21:53:14.364Z" },
     { url = "https://files.pythonhosted.org/packages/d2/ac/a1fa1fc29df0efc89d4946a743b09bdc9500591b5b92083eaf8e93664916/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa", size = 3503075, upload-time = "2026-04-24T14:37:26.826Z" },
     { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900, upload-time = "2026-04-24T14:37:29.233Z" },
     { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637, upload-time = "2026-04-24T14:37:31.472Z" },
@@ -2186,15 +2187,15 @@ wheels = [
 
 [[package]]
 name = "ollama"
-version = "0.6.1"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
 ]
 
 [[package]]
@@ -2393,11 +2394,11 @@ requires-dist = [
     { name = "aiosql", specifier = "==15.0" },
     { name = "aiosqlite", specifier = "==0.22.1" },
     { name = "fastmcp", specifier = "==3.2.4" },
-    { name = "ollama", specifier = "==0.6.1" },
+    { name = "ollama", specifier = "==0.6.2" },
     { name = "packaging", specifier = "==26.2" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pydantic", specifier = "==2.13.3" },
-    { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "google", "vertexai", "groq", "mistral", "cohere", "bedrock", "huggingface", "mcp", "fastmcp", "logfire"], specifier = "==1.87.0" },
+    { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "google", "vertexai", "groq", "mistral", "cohere", "bedrock", "huggingface", "mcp", "fastmcp", "logfire"], specifier = "==1.93.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "textual", specifier = "==8.2.4" },
     { name = "textual-image", specifier = "==0.12.0" },
@@ -2810,7 +2811,7 @@ email = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.87.0"
+version = "1.93.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -2822,9 +2823,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/f9/76c7943f208b09b320dc65a000689929df6a5d3b143d56b48deade6db486/pydantic_ai_slim-1.87.0.tar.gz", hash = "sha256:25822985ca21d6f2995310da915080fc3f75763aec82e815a3388257b06d6b84", size = 573802, upload-time = "2026-04-25T01:09:21.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/44/438dd99c7d044094037e767dab969d704232aab73e4fffd9f9a1f69bded9/pydantic_ai_slim-1.93.0.tar.gz", hash = "sha256:977364ecd3b6a2201e25d917f4efe80895210e44e66cb6983e1fc0477c78910b", size = 639585, upload-time = "2026-05-09T00:23:25.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/90/810dbc478bf063677cf56babc4404f2f0c59794017a5022ac93345a26d75/pydantic_ai_slim-1.87.0-py3-none-any.whl", hash = "sha256:6a9b4f9bcac3709ef47f3b3cda70446c002eb55901038a50d6224ee6743fe31a", size = 732159, upload-time = "2026-04-25T01:09:13.025Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/67/bbfa2eda2493de6027e3322bccc676c8a7062dc5fe89d68cacf9e50889ce/pydantic_ai_slim-1.93.0-py3-none-any.whl", hash = "sha256:6733e3f19c83f4121fb9fe42aee918bd8f402ce670a519ecc898f108378fadb7", size = 804814, upload-time = "2026-05-09T00:23:17.122Z" },
 ]
 
 [package.optional-dependencies]
@@ -2985,7 +2986,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.87.0"
+version = "1.93.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2993,9 +2994,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/fa/b2306c6dbb06e4dfe6ce6b7c5a28b82bee536d965e1dd1800b49c386b389/pydantic_graph-1.87.0.tar.gz", hash = "sha256:0f44848f8e83908ce372491c32ef349dfaf05e29f39fade0bae9309ab4f015cd", size = 59251, upload-time = "2026-04-25T01:09:23.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/4addcd3c9d06fbdf6c0776026d8a5b87e7ebb17c9896ac2452e714bb17c6/pydantic_graph-1.93.0.tar.gz", hash = "sha256:17effd900200aa7b72ec0509a79f36d3e161c2a6ef02dda6285a381e867ab195", size = 59250, upload-time = "2026-05-09T00:23:28.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/9a/e99edfa37527ee04c14db7fc4b8da3f8e9c913f91c541a4b2d08438b461e/pydantic_graph-1.87.0-py3-none-any.whl", hash = "sha256:fd39e4e852808e36163474fe2af48e88a046b5e5e00596730f33c17d2429b7d2", size = 73063, upload-time = "2026-04-25T01:09:16.493Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/bc/5f9eb611c6b9315fb0c6ae58bb82a63d9d9f17340b6c8778319261593fbb/pydantic_graph-1.93.0-py3-none-any.whl", hash = "sha256:ef1b0dcd55a6b5a3544de53a9594216ee8f51ac26bf4be79f7ef310747be598a", size = 73066, upload-time = "2026-05-09T00:23:20.847Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2365,6 +2365,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "vertexai"] },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "textual" },
     { name = "textual-image" },
     { name = "textual-speedups" },
@@ -2400,6 +2401,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.13.3" },
     { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "google", "vertexai", "groq", "mistral", "cohere", "bedrock", "huggingface", "mcp", "fastmcp", "logfire"], specifier = "==1.93.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "textual", specifier = "==8.2.4" },
     { name = "textual-image", specifier = "==0.12.0" },
     { name = "textual-speedups", specifier = "==0.2.1" },
@@ -3190,11 +3192,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Built-in `generate_image` tool.** Delegates to Ollama's `/api/generate` with image-generation models (`x/z-image-turbo`, `x/flux2-klein`, …)

Configure the default model with `OTERM_OLLAMA_IMAGE_MODEL` or override per call via the tool's `model` argument.

Closes #302 
