### PR TITLE
Re-render Markdown on finish_stream to fix code-fence blanking (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Docs site rebuilt with [Zensical](https://zensical.org/).** Replaces MkDocs and Material for MkDocs ahead of MkDocs 2.0's breaking changes. Same content with a refreshed look: custom oterm logo and adaptive favicon, JetBrains Mono code blocks, an announcement banner, a hero landing page.
 
+### Fixed
+
+- **Assistant responses containing code fences no longer go blank after streaming finishes.** ([#308](https://github.com/ggozad/oterm/issues/308)) `MarkdownStream`'s per-delta `Markdown.append` advances the widget's internal parse cursor to the start of the trailing top-level token, so an unclosed-then-closed code fence could leave block state that the next refresh would drop. `finish_stream` now forces a full `Markdown.update` with the accumulated text after stopping each stream.
+
 ## [0.17.1] - 2026-05-10
 
 ### Added

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -940,13 +940,33 @@ class ChatItem(Widget):
         self.app.notify(f"Image saved to {path}")
 
     async def finish_stream(self) -> None:
-        """Drain and stop any active streams started by ``append_*``."""
+        """Drain and stop any active streams started by ``append_*``.
+
+        Per-delta ``Markdown.append`` advances the widget's internal
+        ``_last_parsed_line`` to the start of the trailing top-level token,
+        so an unclosed-then-closed code fence (or any partial block) can
+        leave block state that drops content on the next refresh. Force a
+        full ``Markdown.update`` with the accumulated text after stopping
+        each stream to reset the widget to a clean re-parsed state.
+        """
         if self._response_stream is not None:
             await self._response_stream.stop()
             self._response_stream = None
+            try:
+                response = self.query_one(".response", Markdown)
+            except NoMatches:  # pragma: no cover
+                pass
+            else:
+                await response.update(self.text)
         if self._thinking_stream is not None:
             await self._thinking_stream.stop()
             self._thinking_stream = None
+            try:
+                body = self.query_one(".thinking-body", Markdown)
+            except NoMatches:  # pragma: no cover
+                pass
+            else:
+                await body.update(self.thinking)
 
     def cancel_streams(self) -> None:
         """Cancel in-flight stream tasks without awaiting.

--- a/tests/widgets/test_chat_container.py
+++ b/tests/widgets/test_chat_container.py
@@ -1187,6 +1187,77 @@ class TestChatItemStreaming:
             await item.append_thinking("musing")
             assert item._thinking_stream is not None
             await item.finish_stream()
+
+    async def test_finish_stream_re_renders_full_markdown(
+        self, chat_model, monkeypatch
+    ):
+        """Per-delta ``Markdown.append`` leaves ``_last_parsed_line`` at the
+        start of the trailing top-level token (e.g. an open code fence), so
+        the next refresh can drop the streamed blocks. ``finish_stream`` must
+        force a full ``Markdown.update`` with the accumulated text so the
+        widget is in a clean re-parsed state."""
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            item = ChatItem()
+            item.author = "assistant"
+            await container.query_one("#messageContainer").mount(item)
+            await pilot.pause()
+
+            deltas = [
+                "# Summary\n\n",
+                "## Python Example\n\n",
+                "```python\n",
+                'print("Hello, world!")\n',
+                "```\n",
+            ]
+            for d in deltas:
+                await item.append_text(d)
+            await pilot.pause()
+
+            response = item.query_one(".response", Markdown)
+            thinking = item.query_one(".thinking-body", Markdown)
+            update_calls: list[tuple[Markdown, str]] = []
+            original = Markdown.update
+
+            def _track(self, markdown):
+                update_calls.append((self, markdown))
+                return original(self, markdown)
+
+            monkeypatch.setattr(Markdown, "update", _track)
+            await item.finish_stream()
+            await pilot.pause()
+
+            full = "".join(deltas)
+            assert (response, full) in update_calls
+            assert all(target is not thinking for target, _ in update_calls)
+
+    async def test_finish_stream_re_renders_thinking(self, chat_model, monkeypatch):
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            item = ChatItem()
+            item.author = "assistant"
+            await container.query_one("#messageContainer").mount(item)
+            await pilot.pause()
+
+            await item.append_thinking("step 1\n")
+            await item.append_thinking("```py\nx=1\n```\n")
+            await pilot.pause()
+
+            thinking = item.query_one(".thinking-body", Markdown)
+            update_calls: list[tuple[Markdown, str]] = []
+            original = Markdown.update
+
+            def _track(self, markdown):
+                update_calls.append((self, markdown))
+                return original(self, markdown)
+
+            monkeypatch.setattr(Markdown, "update", _track)
+            await item.finish_stream()
+            await pilot.pause()
+
+            assert (thinking, "step 1\n```py\nx=1\n```\n") in update_calls
             assert item._thinking_stream is None
 
 


### PR DESCRIPTION
Closes #308 