### PR TITLE
Pydantic-ai updates in preparation for 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - **Docs site rebuilt with [Zensical](https://zensical.org/).** Replaces MkDocs and Material for MkDocs ahead of MkDocs 2.0's breaking changes. Same content with a refreshed look: custom oterm logo and adaptive favicon, JetBrains Mono code blocks, an announcement banner, a hero landing page.
+- **MCP layer migrated to pydantic-ai 1.100's `MCPToolset`.** Replaces the deprecated `MCPServer*` classes ahead of their removal in pydantic-ai 2.0. The runtime now uses FastMCP's client under the hood (via `fastmcp-slim[client]`). Existing `mcpServers` config entries — stdio, HTTP, SSE, env-var substitution, WebSocket rejection — keep working unchanged.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - **Docs site rebuilt with [Zensical](https://zensical.org/).** Replaces MkDocs and Material for MkDocs ahead of MkDocs 2.0's breaking changes. Same content with a refreshed look: custom oterm logo and adaptive favicon, JetBrains Mono code blocks, an announcement banner, a hero landing page.
-- **MCP layer migrated to pydantic-ai 1.100's `MCPToolset`.** Replaces the deprecated `MCPServer*` classes ahead of their removal in pydantic-ai 2.0. The runtime now uses FastMCP's client under the hood (via `fastmcp-slim[client]`). Existing `mcpServers` config entries — stdio, HTTP, SSE, env-var substitution, WebSocket rejection — keep working unchanged.
+- **MCP layer migrated to pydantic-ai 1.100's `MCPToolset`.** Replaces the deprecated `MCPServer*` classes ahead of their removal in pydantic-ai 2.0. The runtime now uses FastMCP's client under the hood (via `fastmcp-slim[client]`). Existing `mcpServers` config entries (stdio, HTTP, SSE, env-var substitution, WebSocket rejection) keep working unchanged.
 - **pydantic-ai 1.100 deprecations cleared end-to-end.** Image generation now registers via `capabilities=[NativeTool(...)]`. Streaming reads `run.usage` as a property. Tool-call parts use `NativeToolCallPart` / `NativeToolReturnPart`. Provider ids align with pydantic-ai's new namespace: `openai` → `openai-chat`, `google-gla` → `google`, `google-vertex` → `google-cloud`. Existing chats are rewritten in place by a one-shot store migration (v0.18.0).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Docs site rebuilt with [Zensical](https://zensical.org/).** Replaces MkDocs and Material for MkDocs ahead of MkDocs 2.0's breaking changes. Same content with a refreshed look: custom oterm logo and adaptive favicon, JetBrains Mono code blocks, an announcement banner, a hero landing page.
 - **MCP layer migrated to pydantic-ai 1.100's `MCPToolset`.** Replaces the deprecated `MCPServer*` classes ahead of their removal in pydantic-ai 2.0. The runtime now uses FastMCP's client under the hood (via `fastmcp-slim[client]`). Existing `mcpServers` config entries — stdio, HTTP, SSE, env-var substitution, WebSocket rejection — keep working unchanged.
+- **pydantic-ai 1.100 deprecations cleared end-to-end.** Image generation now registers via `capabilities=[NativeTool(...)]`. Streaming reads `run.usage` as a property. Tool-call parts use `NativeToolCallPart` / `NativeToolReturnPart`. Provider ids align with pydantic-ai's new namespace: `openai` → `openai-chat`, `google-gla` → `google`, `google-vertex` → `google-cloud`. Existing chats are rewritten in place by a one-shot store migration (v0.18.0).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.18.0] - 2026-05-22
 
 ### Changed
 

--- a/docs/app_config.md
+++ b/docs/app_config.md
@@ -102,11 +102,11 @@ When configured, an **OpenAI Compatible** provider appears in the provider dropd
 | Provider          | Provider ID       | Required env var(s)                             |
 | ----------------- | ----------------- | ----------------------------------------------- |
 | Ollama            | `ollama`          | none for local; `OLLAMA_API_KEY` for `ollama.com` cloud models. Endpoint via `OLLAMA_HOST` / `OLLAMA_URL`. |
-| OpenAI            | `openai`          | `OPENAI_API_KEY`                                |
+| OpenAI            | `openai-chat`     | `OPENAI_API_KEY`                                |
 | OpenAI Responses  | `openai-responses`| `OPENAI_API_KEY`                                |
 | Anthropic         | `anthropic`       | `ANTHROPIC_API_KEY`                             |
-| Google AI         | `google-gla`      | `GOOGLE_API_KEY`                                |
-| Google Vertex AI  | `google-vertex`   | `GOOGLE_APPLICATION_CREDENTIALS`                |
+| Google AI         | `google`          | `GOOGLE_API_KEY`                                |
+| Google Vertex AI  | `google-cloud`    | `GOOGLE_APPLICATION_CREDENTIALS`                |
 | Groq              | `groq`            | `GROQ_API_KEY`                                  |
 | Mistral           | `mistral`         | `MISTRAL_API_KEY`                               |
 | Cohere            | `cohere`          | `COHERE_API_KEY`                                |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oterm"
-version = "0.17.2"
+version = "0.18.0"
 description = "The terminal client for Ollama, OpenAI, Anthropic, and any pydantic-ai-supported provider."
 authors = [{ name = "Yiorgis Gozadinos", email = "ggozadinos@gmail.com" }]
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "packaging==26.2",
     "pillow==12.2.0",
     "pydantic==2.13.3",
-    "pydantic-ai-slim[openai,anthropic,google,vertexai,groq,mistral,cohere,bedrock,huggingface,mcp,fastmcp,logfire]==1.93.0",
+    "pydantic-ai-slim[openai,anthropic,google,vertexai,groq,mistral,cohere,bedrock,huggingface,mcp,logfire]==1.100.0",
     "python-dotenv==1.2.2",
     "python-multipart>=0.0.27",
     "textual==8.2.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = ">=3.10"
 dependencies = [
     "aiosql==15.0",
     "aiosqlite==0.22.1",
-    "fastmcp==3.2.4",
     "ollama==0.6.2",
     "packaging==26.2",
     "pillow==12.2.0",

--- a/src/oterm/agent.py
+++ b/src/oterm/agent.py
@@ -2,8 +2,9 @@ from typing import Any
 
 from pydantic_ai import Agent
 from pydantic_ai import Tool as PydanticTool
-from pydantic_ai.builtin_tools import AbstractBuiltinTool, ImageGenerationTool
+from pydantic_ai.capabilities import AbstractCapability, NativeTool
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
+from pydantic_ai.native_tools import ImageGenerationTool
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.toolsets import AbstractToolset
@@ -52,7 +53,7 @@ def get_agent(
     thinking: bool = False,
 ) -> Agent[None, str]:
     pydantic_model: OpenAIChatModel | OpenAIResponsesModel | str
-    builtin_tools: list[AbstractBuiltinTool] = []
+    capabilities: list[AbstractCapability[None]] = []
     if provider == "ollama":
         pydantic_model = OpenAIChatModel(
             model_name=model,
@@ -63,7 +64,7 @@ def get_agent(
         )
     elif provider == "openai-responses":
         pydantic_model = OpenAIResponsesModel(model_name=model)
-        builtin_tools.append(ImageGenerationTool())
+        capabilities.append(NativeTool(ImageGenerationTool()))
     elif provider.startswith("openai-compat/"):
         from oterm.providers import (
             UNRESOLVED_API_KEY,
@@ -94,7 +95,7 @@ def get_agent(
         instructions=system,
         tools=tools or [],
         toolsets=toolsets or [],
-        builtin_tools=builtin_tools,
+        capabilities=capabilities,
         model_settings=_build_model_settings(parameters, thinking, provider),
     )
     return agent

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -25,11 +25,11 @@ from pydantic_ai import (
 from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai.messages import (
     BinaryImage,
-    BuiltinToolCallPart,
-    BuiltinToolReturnPart,
     FilePart,
     FunctionToolResultEvent,
     ModelMessage,
+    NativeToolCallPart,
+    NativeToolReturnPart,
     RetryPromptPart,
     ThinkingPart,
     ToolCallPart,
@@ -260,9 +260,9 @@ class ChatContainer(Widget):
         | ThinkingPartDelta
         | FilePart
         | ToolCallPart
-        | BuiltinToolCallPart
+        | NativeToolCallPart
         | ToolReturnPart
-        | BuiltinToolReturnPart
+        | NativeToolReturnPart
         | RetryPromptPart,
         Any,
     ]:
@@ -304,8 +304,8 @@ class ChatContainer(Widget):
                                     event.part,
                                     (
                                         ToolCallPart,
-                                        BuiltinToolCallPart,
-                                        BuiltinToolReturnPart,
+                                        NativeToolCallPart,
+                                        NativeToolReturnPart,
                                     ),
                                 ):  # pragma: no branch
                                     yield event.part
@@ -313,7 +313,7 @@ class ChatContainer(Widget):
                                 if isinstance(
                                     event.delta, (TextPartDelta, ThinkingPartDelta)
                                 ):  # pragma: no branch
-                                    self._stream_usage = run.usage()
+                                    self._stream_usage = run.usage
                                     yield event.delta
                 elif Agent.is_call_tools_node(node):
                     async with node.stream(run.ctx) as tools_stream:
@@ -332,7 +332,7 @@ class ChatContainer(Widget):
                                 yield event.part
             if run.result is not None:  # pragma: no branch
                 self.pydantic_history = list(run.result.all_messages())
-                self._stream_usage = run.result.usage()
+                self._stream_usage = run.result.usage
 
     async def load_messages(self) -> None:
         message_container = self.query_one("#messageContainer")
@@ -393,9 +393,9 @@ class ChatContainer(Widget):
                     case TextPartDelta(content_delta=delta):
                         text += delta
                         await response_chat_item.append_text(delta)
-                    case ToolCallPart() | BuiltinToolCallPart():
+                    case ToolCallPart() | NativeToolCallPart():
                         await response_chat_item.add_tool_call(piece)
-                    case ToolReturnPart() | BuiltinToolReturnPart():
+                    case ToolReturnPart() | NativeToolReturnPart():
                         response_chat_item.update_tool_result(
                             piece.tool_call_id, piece.content
                         )
@@ -603,9 +603,9 @@ class ChatContainer(Widget):
                         case TextPartDelta(content_delta=delta):
                             text += delta or ""
                             response_chat_item.text = text
-                        case ToolCallPart() | BuiltinToolCallPart():
+                        case ToolCallPart() | NativeToolCallPart():
                             await response_chat_item.add_tool_call(piece)
-                        case ToolReturnPart() | BuiltinToolReturnPart():
+                        case ToolReturnPart() | NativeToolReturnPart():
                             response_chat_item.update_tool_result(
                                 piece.tool_call_id, piece.content
                             )
@@ -738,7 +738,7 @@ class ToolCallItem(Widget):
 
     collapsed: reactive[bool] = reactive(True)
 
-    def __init__(self, call: ToolCallPart | BuiltinToolCallPart, **kwargs: Any) -> None:
+    def __init__(self, call: ToolCallPart | NativeToolCallPart, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.tool_name = call.tool_name
         self.tool_call_id = call.tool_call_id
@@ -897,7 +897,7 @@ class ChatItem(Widget):
             self._refresh_thinking_chrome()
         await self._thinking_stream.write(delta)
 
-    async def add_tool_call(self, call: ToolCallPart | BuiltinToolCallPart) -> None:
+    async def add_tool_call(self, call: ToolCallPart | NativeToolCallPart) -> None:
         """Render an expandable tool-call marker before the response widget."""
         if self.author == "user":
             return

--- a/src/oterm/providers/__init__.py
+++ b/src/oterm/providers/__init__.py
@@ -5,11 +5,11 @@ from oterm.utils import expand_env_vars
 
 PROVIDER_ENV_VARS: dict[str, list[str]] = {
     "ollama": [],
-    "openai": ["OPENAI_API_KEY"],
+    "openai-chat": ["OPENAI_API_KEY"],
     "openai-responses": ["OPENAI_API_KEY"],
     "anthropic": ["ANTHROPIC_API_KEY"],
-    "google-gla": ["GOOGLE_API_KEY"],
-    "google-vertex": ["GOOGLE_APPLICATION_CREDENTIALS"],
+    "google": ["GOOGLE_API_KEY"],
+    "google-cloud": ["GOOGLE_APPLICATION_CREDENTIALS"],
     "groq": ["GROQ_API_KEY"],
     "mistral": ["MISTRAL_API_KEY"],
     "cohere": ["COHERE_API_KEY"],
@@ -22,11 +22,11 @@ PROVIDER_ENV_VARS: dict[str, list[str]] = {
 
 PROVIDER_NAMES: dict[str, str] = {
     "ollama": "Ollama",
-    "openai": "OpenAI",
+    "openai-chat": "OpenAI",
     "openai-responses": "OpenAI Responses",
     "anthropic": "Anthropic",
-    "google-gla": "Google AI",
-    "google-vertex": "Google Vertex AI",
+    "google": "Google AI",
+    "google-cloud": "Google Vertex AI",
     "groq": "Groq",
     "mistral": "Mistral",
     "cohere": "Cohere",
@@ -119,7 +119,7 @@ def _list_anthropic() -> list[str]:
     return sorted(m.id for m in Anthropic().models.list().data)
 
 
-def _list_google_gla() -> list[str]:
+def _list_google() -> list[str]:
     from google import genai
 
     client = genai.Client(api_key=os.getenv("GOOGLE_API_KEY", ""))
@@ -155,10 +155,10 @@ def _list_cohere() -> list[str] | None:
 
 
 _NATIVE_LISTERS: dict[str, Callable[[], list[str] | None]] = {
-    "openai": _list_openai,
+    "openai-chat": _list_openai,
     "openai-responses": _list_openai,
     "anthropic": _list_anthropic,
-    "google-gla": _list_google_gla,
+    "google": _list_google,
     "mistral": _list_mistral,
     "cohere": _list_cohere,
 }

--- a/src/oterm/providers/capabilities.py
+++ b/src/oterm/providers/capabilities.py
@@ -38,7 +38,7 @@ def is_chat_model(provider: str, model: str) -> bool:
         return True
     if provider == "anthropic":
         return True
-    if provider in ("google-gla", "google-vertex"):
+    if provider in ("google", "google-cloud"):
         return "gemini" in model
     if provider == "mistral":
         return not model.startswith("mistral-embed")
@@ -94,12 +94,12 @@ def _supports_vision(provider: str, model: str) -> bool:
             or "claude-sonnet-4" in model
             or "claude-haiku-4" in model
         )
-    if provider in ("openai", "openai-responses"):
+    if provider in ("openai-chat", "openai-responses"):
         return any(
             model.startswith(p)
             for p in ("gpt-4o", "gpt-4-turbo", "gpt-4.1", "gpt-5", "o1", "o3", "o4")
         )
-    if provider in ("google-gla", "google-vertex"):
+    if provider in ("google", "google-cloud"):
         return "gemini" in model
     if provider == "groq":
         return "vision" in model or "llava" in model

--- a/src/oterm/providers/settings.py
+++ b/src/oterm/providers/settings.py
@@ -16,13 +16,13 @@ from pydantic_ai.settings import ModelSettings
 
 PROVIDER_SETTINGS_TYPE: dict[str, type] = {
     "ollama": OpenAIChatModelSettings,
-    "openai": OpenAIChatModelSettings,
+    "openai-chat": OpenAIChatModelSettings,
     "openai-responses": OpenAIResponsesModelSettings,
     "deepseek": OpenAIChatModelSettings,
     "grok": OpenAIChatModelSettings,
     "anthropic": AnthropicModelSettings,
-    "google-gla": GoogleModelSettings,
-    "google-vertex": GoogleModelSettings,
+    "google": GoogleModelSettings,
+    "google-cloud": GoogleModelSettings,
     "groq": GroqModelSettings,
     "mistral": MistralModelSettings,
     "cohere": CohereModelSettings,

--- a/src/oterm/store/upgrades/__init__.py
+++ b/src/oterm/store/upgrades/__init__.py
@@ -1,3 +1,4 @@
 from oterm.store.upgrades.v0_15_0 import upgrades as v0_15_0_upgrades
+from oterm.store.upgrades.v0_18_0 import upgrades as v0_18_0_upgrades
 
-upgrades = v0_15_0_upgrades
+upgrades = v0_15_0_upgrades + v0_18_0_upgrades

--- a/src/oterm/store/upgrades/v0_18_0.py
+++ b/src/oterm/store/upgrades/v0_18_0.py
@@ -1,0 +1,30 @@
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import aiosqlite
+
+# pydantic-ai 1.100 renamed provider ids ahead of 2.0:
+#   google-gla    → google
+#   google-vertex → google-cloud
+# and warned on bare `openai:` (2.0 will switch that namespace to the
+# Responses API). oterm now stores the new ids; existing chat rows get
+# rewritten in place.
+_PROVIDER_RENAMES = {
+    "google-gla": "google",
+    "google-vertex": "google-cloud",
+    "openai": "openai-chat",
+}
+
+
+async def rename_providers(db_path: Path) -> None:
+    async with aiosqlite.connect(db_path) as connection:
+        for old, new in _PROVIDER_RENAMES.items():
+            await connection.execute(
+                "UPDATE chat SET provider = ? WHERE provider = ?", (new, old)
+            )
+        await connection.commit()
+
+
+upgrades: list[tuple[str, list[Callable[[Path], Awaitable[None]]]]] = [
+    ("0.18.0", [rename_providers]),
+]

--- a/src/oterm/tools/mcp/logging.py
+++ b/src/oterm/tools/mcp/logging.py
@@ -1,10 +1,9 @@
-from mcp.client.session import LoggingFnT
 from mcp.types import LoggingMessageNotificationParams
 
 from oterm.log import log
 
 
-class Logger(LoggingFnT):
+class Logger:
     async def __call__(self, params: LoggingMessageNotificationParams) -> None:
         if params.level == "error" or params.level == "critical":
             log.error(params.data)

--- a/src/oterm/tools/mcp/logging.py
+++ b/src/oterm/tools/mcp/logging.py
@@ -1,15 +1,14 @@
-from mcp.types import LoggingMessageNotificationParams
+from fastmcp.client.logging import LogMessage
 
 from oterm.log import log
 
 
-class Logger:
-    async def __call__(self, params: LoggingMessageNotificationParams) -> None:
-        if params.level == "error" or params.level == "critical":
-            log.error(params.data)
-        elif params.level == "warning":
-            log.warning(params.data)
-        elif params.level == "info":
-            log.info(params.data)
-        elif params.level == "debug":  # pragma: no branch
-            log.debug(params.data)
+async def log_handler(params: LogMessage) -> None:
+    if params.level == "error" or params.level == "critical":
+        log.error(params.data)
+    elif params.level == "warning":
+        log.warning(params.data)
+    elif params.level == "info":
+        log.info(params.data)
+    elif params.level == "debug":  # pragma: no branch
+        log.debug(params.data)

--- a/src/oterm/tools/mcp/setup.py
+++ b/src/oterm/tools/mcp/setup.py
@@ -1,12 +1,7 @@
 import contextlib
 
-from pydantic_ai.mcp import (
-    MCPServer,
-    MCPServerConfig,
-    MCPServerSSE,
-    MCPServerStdio,
-    MCPServerStreamableHTTP,
-)
+from fastmcp.client.transports import StdioTransport
+from pydantic_ai.mcp import MCPToolset
 
 from oterm.config import appConfig
 from oterm.log import log
@@ -26,49 +21,56 @@ class ToolMeta(dict):
     """Typed shape stored in `mcp_tool_meta`: {name, description}."""
 
 
-mcp_servers: dict[str, MCPServer] = {}
+mcp_servers: dict[str, MCPToolset] = {}
 mcp_tool_meta: dict[str, list[ToolMeta]] = {}
 _exit_stack: contextlib.AsyncExitStack | None = None
 
 
-def _build_servers(raw: dict[str, dict]) -> dict[str, MCPServer]:
-    """Build MCP servers from oterm's config.
+def _build_toolset(name: str, entry: dict) -> MCPToolset:
+    """Build a single MCPToolset from an oterm `mcpServers` config entry.
 
-    Schema matches pydantic-ai's MCPServerConfig: each entry is either an
-    stdio shape (`command` / `args` / `env`) or an HTTP shape (`url` /
-    `headers`). URLs ending in `/sse` resolve to MCPServerSSE.
+    Accepts either an HTTP shape (`url` / `headers`) or a stdio shape
+    (`command` / `args` / `env` / `cwd`). Rejects WebSocket URLs explicitly
+    so users get a clear error instead of a transport-layer failure.
     """
-    expanded = expand_env_vars(raw)
-
-    # Pre-validate: reject ws:// URLs explicitly so users get a clear error
-    # instead of pydantic-ai trying to speak streamable-HTTP to a websocket.
-    for name, entry in expanded.items():
-        url = entry.get("url") if isinstance(entry, dict) else None
-        if isinstance(url, str) and url.startswith(("ws://", "wss://")):
+    url = entry.get("url")
+    if isinstance(url, str):
+        if url.startswith(("ws://", "wss://")):
             raise ValueError(
                 f"MCP server {name!r}: WebSocket transport is no longer supported. "
                 "Use HTTP (http:// or https://) transport instead."
             )
+        return MCPToolset(
+            url,
+            id=name,
+            headers=entry.get("headers"),
+            log_handler=Logger(),
+        )
+    transport = StdioTransport(
+        command=entry["command"],
+        args=list(entry.get("args") or []),
+        env={**_STDIO_LOG_ENV, **(entry.get("env") or {})},
+        cwd=entry.get("cwd"),
+    )
+    return MCPToolset(transport, id=name, log_handler=Logger())
 
-    config = MCPServerConfig.model_validate({"mcpServers": expanded})
 
-    servers: dict[str, MCPServer] = {}
-    for name, server in config.mcp_servers.items():
-        server.id = name
-        server.log_handler = Logger()
-        # No sampling_model is configured, so disable sampling rather than let
-        # pydantic-ai advertise it and then crash when a server requests it.
-        server.allow_sampling = False
-        if isinstance(server, MCPServerStdio):
-            server.env = {**_STDIO_LOG_ENV, **(server.env or {})}
-        servers[name] = server
-    return servers
+def _build_toolsets(raw: dict[str, dict]) -> dict[str, MCPToolset]:
+    """Build MCPToolsets from oterm's `mcpServers` config block.
+
+    Schema matches the Claude Desktop / pydantic-ai convention: each entry is
+    either an stdio shape (`command` / `args` / `env` / `cwd`) or an HTTP
+    shape (`url` / `headers`). URLs ending in `/sse` resolve to an SSE
+    transport automatically; other HTTP URLs use Streamable HTTP.
+    """
+    expanded = expand_env_vars(raw)
+    return {name: _build_toolset(name, entry) for name, entry in expanded.items()}
 
 
 async def setup_mcp_servers() -> dict[str, list[ToolMeta]]:
     """Build, enter, and probe each configured MCP server.
 
-    Returns a registry of tool metadata per server name. The server instances
+    Returns a registry of tool metadata per server name. The toolset instances
     themselves are stored in module-global `mcp_servers` and kept entered for
     the app lifetime via `_exit_stack`.
     """
@@ -79,7 +81,7 @@ async def setup_mcp_servers() -> dict[str, list[ToolMeta]]:
     _exit_stack = contextlib.AsyncExitStack()
 
     try:
-        built = _build_servers(configured)
+        built = _build_toolsets(configured)
     except ValueError as e:
         log.error(f"MCP config rejected: {e}")
         return mcp_tool_meta
@@ -87,14 +89,14 @@ async def setup_mcp_servers() -> dict[str, list[ToolMeta]]:
         log.error(f"MCP config could not be parsed: {e}")
         return mcp_tool_meta
 
-    for name, server in built.items():
+    for name, toolset in built.items():
         try:
-            await _exit_stack.enter_async_context(server)
-            tools = await server.list_tools()
+            await _exit_stack.enter_async_context(toolset)
+            tools = await toolset.list_tools()
         except Exception as e:
             log.error(f"MCP server {name!r} failed to initialize: {e}")
             continue
-        mcp_servers[name] = server
+        mcp_servers[name] = toolset
         mcp_tool_meta[name] = [
             ToolMeta(name=t.name, description=t.description or "") for t in tools
         ]
@@ -116,12 +118,7 @@ async def teardown_mcp_servers() -> None:
         mcp_tool_meta.clear()
 
 
-# Re-export for tests + back-compat with anything that imported MCPServerSSE.
 __all__ = [
-    "MCPServer",
-    "MCPServerSSE",
-    "MCPServerStdio",
-    "MCPServerStreamableHTTP",
     "ToolMeta",
     "mcp_servers",
     "mcp_tool_meta",

--- a/src/oterm/tools/mcp/setup.py
+++ b/src/oterm/tools/mcp/setup.py
@@ -5,7 +5,7 @@ from pydantic_ai.mcp import MCPToolset
 
 from oterm.config import appConfig
 from oterm.log import log
-from oterm.tools.mcp.logging import Logger
+from oterm.tools.mcp.logging import log_handler
 from oterm.utils import expand_env_vars
 
 # Subprocess env overrides that quiet common MCP server runtimes.
@@ -44,7 +44,7 @@ def _build_toolset(name: str, entry: dict) -> MCPToolset:
             url,
             id=name,
             headers=entry.get("headers"),
-            log_handler=Logger(),
+            log_handler=log_handler,
         )
     transport = StdioTransport(
         command=entry["command"],
@@ -52,7 +52,7 @@ def _build_toolset(name: str, entry: dict) -> MCPToolset:
         env={**_STDIO_LOG_ENV, **(entry.get("env") or {})},
         cwd=entry.get("cwd"),
     )
-    return MCPToolset(transport, id=name, log_handler=Logger())
+    return MCPToolset(transport, id=name, log_handler=log_handler)
 
 
 def _build_toolsets(raw: dict[str, dict]) -> dict[str, MCPToolset]:

--- a/tests/_stream_helpers.py
+++ b/tests/_stream_helpers.py
@@ -7,6 +7,7 @@ Provides a `FunctionModel` variant whose `stream_function` may also yield
 from contextlib import asynccontextmanager
 
 from pydantic_ai import Agent
+from pydantic_ai._instrumentation import get_instructions
 from pydantic_ai.messages import FilePart
 from pydantic_ai.models.function import (
     AgentInfo,
@@ -52,7 +53,7 @@ def make_file_aware_agent(stream_fn) -> Agent:
             output_tools=mrp.output_tools,
             model_settings=model_settings,
             model_request_parameters=mrp,
-            instructions=self._get_instructions(messages, mrp),
+            instructions=get_instructions(messages, mrp),
         )
         response_stream = PeekableAsyncStream(
             self.stream_function(messages, agent_info)

--- a/tests/_stream_helpers.py
+++ b/tests/_stream_helpers.py
@@ -7,7 +7,6 @@ Provides a `FunctionModel` variant whose `stream_function` may also yield
 from contextlib import asynccontextmanager
 
 from pydantic_ai import Agent
-from pydantic_ai._instrumentation import get_instructions
 from pydantic_ai.messages import FilePart
 from pydantic_ai.models.function import (
     AgentInfo,
@@ -53,7 +52,7 @@ def make_file_aware_agent(stream_fn) -> Agent:
             output_tools=mrp.output_tools,
             model_settings=model_settings,
             model_request_parameters=mrp,
-            instructions=get_instructions(messages, mrp),
+            instructions=None,
         )
         response_stream = PeekableAsyncStream(
             self.stream_function(messages, agent_info)

--- a/tests/modals/test_chat_edit.py
+++ b/tests/modals/test_chat_edit.py
@@ -351,7 +351,9 @@ async def test_provider_change_resets_model(app_config, monkeypatch):
     import oterm.providers as prov
 
     monkeypatch.setattr(prov, "list_models", lambda p: ["gpt-4o", "gpt-5"])
-    monkeypatch.setattr(prov, "get_available_providers", lambda: ["ollama", "openai"])
+    monkeypatch.setattr(
+        prov, "get_available_providers", lambda: ["ollama", "openai-chat"]
+    )
 
     app = _Host()
     async with app.run_test() as pilot:
@@ -362,11 +364,13 @@ async def test_provider_change_resets_model(app_config, monkeypatch):
 
         from textual.widgets import Select
 
-        event = Select.Changed(screen.query_one("#provider-select", Select), "openai")
+        event = Select.Changed(
+            screen.query_one("#provider-select", Select), "openai-chat"
+        )
         await screen.on_select_changed(event)
         await pilot.pause()
 
-        assert screen.provider == "openai"
+        assert screen.provider == "openai-chat"
         assert screen.model_name == ""
 
 

--- a/tests/tools/test_mcp_logging.py
+++ b/tests/tools/test_mcp_logging.py
@@ -1,12 +1,11 @@
-from mcp.types import LoggingMessageNotificationParams
+from fastmcp.client.logging import LogMessage
 
-from oterm.tools.mcp.logging import Logger
+from oterm.tools.mcp.logging import log_handler
 
 
-async def test_logger_routes_by_level_to_log_lines():
+async def test_log_handler_routes_by_level_to_log_lines():
     import oterm.log
 
-    logger = Logger()
     before = len(oterm.log.log_lines)
 
     for level, data in (
@@ -16,7 +15,7 @@ async def test_logger_routes_by_level_to_log_lines():
         ("error", "E"),
         ("critical", "C"),
     ):
-        await logger(LoggingMessageNotificationParams(level=level, data=data))
+        await log_handler(LogMessage(level=level, data=data))
 
     messages = [msg for _, msg in oterm.log.log_lines[before:]]
     assert "D" in messages

--- a/tests/tools/test_mcp_setup.py
+++ b/tests/tools/test_mcp_setup.py
@@ -50,6 +50,12 @@ class TestBuildToolsets:
         env = _stdio(built["stdio"]).env or {}
         assert env["LOGLEVEL"] == "DEBUG"
 
+    def test_stdio_cwd_is_forwarded(self, tmp_path):
+        built = _build_toolsets(
+            {"stdio": {"command": "mcp", "args": [], "cwd": str(tmp_path)}}
+        )
+        assert _stdio(built["stdio"]).cwd == str(tmp_path)
+
     def test_http_config(self):
         built = _build_toolsets({"http": {"url": "http://example.com/mcp"}})
         assert isinstance(built["http"].client.transport, StreamableHttpTransport)

--- a/tests/tools/test_mcp_setup.py
+++ b/tests/tools/test_mcp_setup.py
@@ -1,50 +1,61 @@
 import pytest
-from pydantic_ai.mcp import MCPServerSSE, MCPServerStdio, MCPServerStreamableHTTP
+from fastmcp.client.transports import (
+    SSETransport,
+    StdioTransport,
+    StreamableHttpTransport,
+)
+from pydantic_ai.mcp import MCPToolset
 
 from oterm.tools.mcp.setup import (
-    _build_servers,
+    _build_toolsets,
     mcp_servers,
     setup_mcp_servers,
     teardown_mcp_servers,
 )
 
 
-class TestBuildServers:
+def _stdio(toolset: MCPToolset) -> StdioTransport:
+    transport = toolset.client.transport
+    assert isinstance(transport, StdioTransport)
+    return transport
+
+
+def _http(toolset: MCPToolset) -> StreamableHttpTransport:
+    transport = toolset.client.transport
+    assert isinstance(transport, StreamableHttpTransport)
+    return transport
+
+
+class TestBuildToolsets:
     def test_stdio_config(self):
-        built = _build_servers(
+        built = _build_toolsets(
             {"stdio": {"command": "mcp", "args": ["run", "x"], "env": {"FOO": "bar"}}}
         )
-        server = built["stdio"]
-        assert isinstance(server, MCPServerStdio)
-        env = server.env or {}
+        env = _stdio(built["stdio"]).env or {}
         assert env["LOGLEVEL"] == "ERROR"
         assert env["FOO"] == "bar"
 
     def test_stdio_does_not_inherit_parent_env(self, monkeypatch):
         """Secure default: parent env (PATH, secrets, etc.) is not leaked."""
         monkeypatch.setenv("SECRET_TOKEN", "leak-me")
-        built = _build_servers({"stdio": {"command": "mcp", "args": []}})
-        server = built["stdio"]
-        assert isinstance(server, MCPServerStdio)
-        env = server.env or {}
+        built = _build_toolsets({"stdio": {"command": "mcp", "args": []}})
+        env = _stdio(built["stdio"]).env or {}
         assert "SECRET_TOKEN" not in env
         assert "PATH" not in env
 
     def test_stdio_user_env_overrides_logging_overrides(self):
-        built = _build_servers(
+        built = _build_toolsets(
             {"stdio": {"command": "mcp", "args": [], "env": {"LOGLEVEL": "DEBUG"}}}
         )
-        server = built["stdio"]
-        assert isinstance(server, MCPServerStdio)
-        env = server.env or {}
+        env = _stdio(built["stdio"]).env or {}
         assert env["LOGLEVEL"] == "DEBUG"
 
     def test_http_config(self):
-        built = _build_servers({"http": {"url": "http://example.com/mcp"}})
-        assert isinstance(built["http"], MCPServerStreamableHTTP)
+        built = _build_toolsets({"http": {"url": "http://example.com/mcp"}})
+        assert isinstance(built["http"].client.transport, StreamableHttpTransport)
 
     def test_http_with_authorization_header(self):
-        built = _build_servers(
+        built = _build_toolsets(
             {
                 "http": {
                     "url": "http://example.com/mcp",
@@ -52,35 +63,24 @@ class TestBuildServers:
                 }
             }
         )
-        server = built["http"]
-        assert isinstance(server, MCPServerStreamableHTTP)
-        assert server.headers == {"Authorization": "Bearer secret"}
+        transport = _http(built["http"])
+        assert transport.headers == {"Authorization": "Bearer secret"}
 
-    def test_url_ending_in_sse_resolves_to_sse_server(self):
-        built = _build_servers({"sse": {"url": "http://example.com/sse"}})
-        assert isinstance(built["sse"], MCPServerSSE)
-
-    def test_sampling_is_disabled(self):
-        built = _build_servers(
-            {
-                "stdio": {"command": "mcp", "args": []},
-                "http": {"url": "http://example.com/mcp"},
-            }
-        )
-        assert built["stdio"].allow_sampling is False
-        assert built["http"].allow_sampling is False
+    def test_url_ending_in_sse_resolves_to_sse_transport(self):
+        built = _build_toolsets({"sse": {"url": "http://example.com/sse"}})
+        assert isinstance(built["sse"].client.transport, SSETransport)
 
     def test_websocket_url_rejected(self):
         with pytest.raises(ValueError, match="WebSocket transport"):
-            _build_servers({"ws": {"url": "ws://example.com/mcp"}})
+            _build_toolsets({"ws": {"url": "ws://example.com/mcp"}})
 
     def test_wss_url_rejected(self):
         with pytest.raises(ValueError, match="WebSocket transport"):
-            _build_servers({"wss": {"url": "wss://example.com/mcp"}})
+            _build_toolsets({"wss": {"url": "wss://example.com/mcp"}})
 
     def test_env_var_substitution_in_env_values(self, monkeypatch):
         monkeypatch.setenv("MY_TOKEN", "shh")
-        built = _build_servers(
+        built = _build_toolsets(
             {
                 "stdio": {
                     "command": "mcp",
@@ -89,14 +89,12 @@ class TestBuildServers:
                 }
             }
         )
-        server = built["stdio"]
-        assert isinstance(server, MCPServerStdio)
-        env = server.env or {}
+        env = _stdio(built["stdio"]).env or {}
         assert env["GITHUB_TOKEN"] == "shh"
 
     def test_env_var_substitution_in_command_and_args(self, monkeypatch):
         monkeypatch.setenv("MCP_BIN", "/opt/bin/mcp")
-        built = _build_servers(
+        built = _build_toolsets(
             {
                 "stdio": {
                     "command": "${MCP_BIN}",
@@ -104,14 +102,13 @@ class TestBuildServers:
                 }
             }
         )
-        server = built["stdio"]
-        assert isinstance(server, MCPServerStdio)
-        assert server.command == "/opt/bin/mcp"
-        assert list(server.args) == ["--config", "/opt/bin/mcp.conf"]
+        transport = _stdio(built["stdio"])
+        assert transport.command == "/opt/bin/mcp"
+        assert list(transport.args) == ["--config", "/opt/bin/mcp.conf"]
 
     def test_env_var_substitution_with_default(self, monkeypatch):
         monkeypatch.delenv("MISSING_VAR", raising=False)
-        built = _build_servers(
+        built = _build_toolsets(
             {
                 "stdio": {
                     "command": "mcp",
@@ -120,15 +117,13 @@ class TestBuildServers:
                 }
             }
         )
-        server = built["stdio"]
-        assert isinstance(server, MCPServerStdio)
-        env = server.env or {}
+        env = _stdio(built["stdio"]).env or {}
         assert env["DEFAULTED"] == "fallback"
 
     def test_env_var_substitution_missing_raises(self, monkeypatch):
         monkeypatch.delenv("UNDEFINED_VAR", raising=False)
         with pytest.raises(ValueError, match="UNDEFINED_VAR"):
-            _build_servers(
+            _build_toolsets(
                 {
                     "stdio": {
                         "command": "mcp",
@@ -140,7 +135,7 @@ class TestBuildServers:
 
     def test_env_var_substitution_in_authorization_header(self, monkeypatch):
         monkeypatch.setenv("BEARER", "s3cret")
-        built = _build_servers(
+        built = _build_toolsets(
             {
                 "http": {
                     "url": "http://x/mcp",
@@ -148,9 +143,8 @@ class TestBuildServers:
                 }
             }
         )
-        server = built["http"]
-        assert isinstance(server, MCPServerStreamableHTTP)
-        assert server.headers == {"Authorization": "Bearer s3cret"}
+        transport = _http(built["http"])
+        assert transport.headers == {"Authorization": "Bearer s3cret"}
 
 
 class TestSetupAndTeardown:
@@ -203,14 +197,14 @@ class TestSetupAndTeardown:
     async def test_unexpected_exception_during_build_is_logged(
         self, app_config, monkeypatch
     ):
-        """Non-ValueError exceptions during _build_servers are caught and logged."""
+        """Non-ValueError exceptions during _build_toolsets are caught and logged."""
         import oterm.log
         import oterm.tools.mcp.setup as setup_mod
 
         def boom(_raw):
             raise RuntimeError("kaboom")
 
-        monkeypatch.setattr(setup_mod, "_build_servers", boom)
+        monkeypatch.setattr(setup_mod, "_build_toolsets", boom)
         app_config.set("mcpServers", {"x": {"url": "http://example.com/mcp"}})
         before = len(oterm.log.log_lines)
         try:

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -131,14 +131,14 @@ class TestGetAgent:
         assert agent.model.client.api_key == OLLAMA_API_KEY
 
     def test_openai_responses_provider_enables_image_generation_tool(self, monkeypatch):
-        from pydantic_ai.builtin_tools import ImageGenerationTool
         from pydantic_ai.models.openai import OpenAIResponsesModel
+        from pydantic_ai.native_tools import ImageGenerationTool
 
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         agent = get_agent(provider="openai-responses", model="gpt-5.4")
         assert isinstance(agent, Agent)
         assert isinstance(agent.model, OpenAIResponsesModel)
-        assert any(isinstance(t, ImageGenerationTool) for t in agent._cap_builtin_tools)
+        assert any(isinstance(t, ImageGenerationTool) for t in agent._cap_native_tools)
 
     def test_openai_compat_missing_endpoint_raises(self, app_config):
         with pytest.raises(ValueError, match="not configured"):

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -37,7 +37,7 @@ class TestBuildModelSettings:
         assert settings["max_tokens"] == 128
         assert "ignored" not in settings
 
-    @pytest.mark.parametrize("provider", ["openai", "anthropic", "groq", "ollama"])
+    @pytest.mark.parametrize("provider", ["openai-chat", "anthropic", "groq", "ollama"])
     def test_seed_roundtrips_for_supported_providers(self, provider):
         settings = _build_model_settings(
             {"seed": 42}, thinking=False, provider=provider

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -13,12 +13,12 @@ class TestIsChatModel:
         [
             ("ollama", "llama3"),
             ("anthropic", "claude-3-haiku"),
-            ("google-gla", "gemini-1.5"),
-            ("google-vertex", "gemini-2.0-flash"),
+            ("google", "gemini-1.5"),
+            ("google-cloud", "gemini-2.0-flash"),
             ("mistral", "mistral-large"),
             ("cohere", "command-r"),
-            ("openai", "gpt-4o"),
-            ("openai", "o1-preview"),
+            ("openai-chat", "gpt-4o"),
+            ("openai-chat", "o1-preview"),
         ],
     )
     def test_chat_models_accepted(self, provider, model):
@@ -27,16 +27,16 @@ class TestIsChatModel:
     @pytest.mark.parametrize(
         "provider,model",
         [
-            ("google-gla", "embedding-001"),
+            ("google", "embedding-001"),
             ("mistral", "mistral-embed"),
             ("cohere", "embed-v3"),
             ("cohere", "rerank-v3"),
-            ("openai", "dall-e-3"),
-            ("openai", "tts-1"),
-            ("openai", "whisper-1"),
-            ("openai", "text-embedding-3-small"),
-            ("openai", "gpt-4o-transcribe"),
-            ("openai", "gpt-4o-realtime-preview"),
+            ("openai-chat", "dall-e-3"),
+            ("openai-chat", "tts-1"),
+            ("openai-chat", "whisper-1"),
+            ("openai-chat", "text-embedding-3-small"),
+            ("openai-chat", "gpt-4o-transcribe"),
+            ("openai-chat", "gpt-4o-realtime-preview"),
         ],
     )
     def test_non_chat_models_rejected(self, provider, model):
@@ -68,15 +68,15 @@ class TestGetCapabilities:
 
     def test_openai_vision_models(self):
         for model in ("gpt-4o", "gpt-4-turbo", "gpt-4.1", "gpt-5", "o1", "o3", "o4"):
-            caps = get_capabilities("openai", model)
+            caps = get_capabilities("openai-chat", model)
             assert caps.supports_vision is True, model
 
     def test_google_gla_gemini_vision(self):
-        caps = get_capabilities("google-gla", "gemini-1.5-pro")
+        caps = get_capabilities("google", "gemini-1.5-pro")
         assert caps.supports_vision is True
 
     def test_google_gla_thinking_branch(self):
-        caps = get_capabilities("google-gla", "gemini-2.5-pro")
+        caps = get_capabilities("google", "gemini-2.5-pro")
         assert caps.supports_thinking is True
 
     def test_groq_deepseek_r1_thinking(self):
@@ -130,10 +130,10 @@ class TestGetCapabilities:
 
     def test_openai_o1_thinking_via_profile(self):
         # OpenAIProvider.model_profile resolves o1 as reasoning-capable.
-        assert get_capabilities("openai", "o1").supports_thinking is True
+        assert get_capabilities("openai-chat", "o1").supports_thinking is True
 
     def test_openai_gpt4o_no_thinking(self):
-        assert get_capabilities("openai", "gpt-4o").supports_thinking is False
+        assert get_capabilities("openai-chat", "gpt-4o").supports_thinking is False
 
     def test_unknown_provider_thinking_falls_back(self):
         # huggingface isn't in pydantic-ai's infer_provider_class map; we

--- a/tests/unit/test_provider_settings.py
+++ b/tests/unit/test_provider_settings.py
@@ -40,5 +40,5 @@ def test_provider_specific_keys_are_present():
     assert "anthropic_thinking" in anthropic_keys
     assert COMMON_FIELDS <= anthropic_keys
 
-    openai_keys = get_supported_setting_keys("openai")
+    openai_keys = get_supported_setting_keys("openai-chat")
     assert "openai_reasoning_effort" in openai_keys

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -98,11 +98,11 @@ class TestGetAvailableProviders:
 
     def test_provider_included_when_env_var_present(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
-        assert "openai" in get_available_providers()
+        assert "openai-chat" in get_available_providers()
 
     def test_provider_excluded_when_env_var_missing(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        assert "openai" not in get_available_providers()
+        assert "openai-chat" not in get_available_providers()
 
     def test_bedrock_needs_both_env_vars(self, monkeypatch):
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "x")
@@ -187,14 +187,14 @@ class TestListModelsFromApi:
         _install_fake_module(
             monkeypatch, "openai", {"OpenAI": lambda **kw: _FakeClient(items)}
         )
-        assert _list_models_from_api("openai") == ["gpt-3.5-turbo", "gpt-4o"]
+        assert _list_models_from_api("openai-chat") == ["gpt-3.5-turbo", "gpt-4o"]
 
     def test_openai_error_returns_none(self, monkeypatch):
         def boom(**kw):
             raise RuntimeError("down")
 
         _install_fake_module(monkeypatch, "openai", {"OpenAI": boom})
-        assert _list_models_from_api("openai") is None
+        assert _list_models_from_api("openai-chat") is None
 
     def test_anthropic(self, monkeypatch):
         items = [_FakeModelItem("claude-4"), _FakeModelItem("claude-3-haiku")]
@@ -259,7 +259,7 @@ class TestListModelsFromApi:
         _install_fake_module(monkeypatch, "openai", {"OpenAI": boom})
         assert _list_models_from_api("deepseek") is None
 
-    def test_google_gla(self, monkeypatch):
+    def test_google(self, monkeypatch):
         class _Model:
             def __init__(self, name):
                 self.name = name
@@ -279,15 +279,15 @@ class TestListModelsFromApi:
             {"genai": type("M", (), {"Client": _GenaiClient})()},
         )
         monkeypatch.setenv("GOOGLE_API_KEY", "k")
-        assert _list_models_from_api("google-gla") == ["gemini-flash", "gemini-pro"]
+        assert _list_models_from_api("google") == ["gemini-flash", "gemini-pro"]
 
-    def test_google_gla_error_returns_none(self, monkeypatch):
+    def test_google_error_returns_none(self, monkeypatch):
         def boom(**kw):
             raise RuntimeError("x")
 
         fake = type("M", (), {"Client": boom})
         _install_fake_module(monkeypatch, "google", {"genai": fake})
-        assert _list_models_from_api("google-gla") is None
+        assert _list_models_from_api("google") is None
 
     def test_mistral(self, monkeypatch):
         # Build fake mistralai sub-modules the source imports.
@@ -424,8 +424,8 @@ class TestListModelsFromApi:
 
 class TestListModelsFromKnown:
     def test_prefix_matches(self):
-        models = _list_models_from_known("openai")
-        assert all(not m.startswith("openai:") for m in models)
+        models = _list_models_from_known("openai-chat")
+        assert all(not m.startswith("openai-chat:") for m in models)
         assert any("gpt" in m for m in models)
 
 
@@ -457,7 +457,7 @@ class TestListModels:
             monkeypatch, "openai", {"OpenAI": lambda **kw: _FakeClient(items)}
         )
         monkeypatch.setenv("OPENAI_API_KEY", "k")
-        models = list_models("openai")
+        models = list_models("openai-chat")
         assert "gpt-4o" in models
         assert "text-embedding-3-small" not in models
 
@@ -467,5 +467,5 @@ class TestListModels:
 
         _install_fake_module(monkeypatch, "openai", {"OpenAI": boom})
         monkeypatch.setenv("OPENAI_API_KEY", "k")
-        models = list_models("openai")
+        models = list_models("openai-chat")
         assert any("gpt" in m for m in models)

--- a/tests/unit/test_store_upgrades.py
+++ b/tests/unit/test_store_upgrades.py
@@ -7,6 +7,7 @@ from oterm.store.upgrades.v0_15_0 import (
     migrate_parameters,
     migrate_tools_to_names,
 )
+from oterm.store.upgrades.v0_18_0 import rename_providers
 
 
 async def _old_chat_schema(db_path):
@@ -208,3 +209,34 @@ class TestMigrateToolsToNames:
         async with aiosqlite.connect(db) as c:
             rows = await c.execute_fetchall("SELECT tools FROM chat")
             assert list(rows)[0][0] == "[]"
+
+
+class TestRenameProviders:
+    async def test_renames_deprecated_provider_ids(self, tmp_path):
+        db = tmp_path / "store.db"
+        await _old_chat_schema(db)
+        await add_provider_remove_format_keep_alive(db)
+        async with aiosqlite.connect(db) as c:
+            await c.executemany(
+                "INSERT INTO chat(name, model, provider) VALUES(?, ?, ?)",
+                [
+                    ("a", "gpt-4o", "openai"),
+                    ("b", "gemini-1.5", "google-gla"),
+                    ("c", "gemini-1.5", "google-vertex"),
+                    ("d", "llama3", "ollama"),
+                ],
+            )
+            await c.commit()
+
+        await rename_providers(db)
+
+        async with aiosqlite.connect(db) as c:
+            rows = await c.execute_fetchall(
+                "SELECT name, provider FROM chat ORDER BY name"
+            )
+            assert list(rows) == [
+                ("a", "openai-chat"),
+                ("b", "google"),
+                ("c", "google-cloud"),
+                ("d", "ollama"),
+            ]

--- a/uv.lock
+++ b/uv.lock
@@ -1007,6 +1007,33 @@ wheels = [
 ]
 
 [[package]]
+name = "fastmcp-slim"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2259,7 +2286,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pillow" },
     { name = "pydantic" },
-    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "vertexai"] },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "cohere", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "vertexai"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "textual" },
@@ -2294,7 +2321,7 @@ requires-dist = [
     { name = "packaging", specifier = "==26.2" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pydantic", specifier = "==2.13.3" },
-    { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "google", "vertexai", "groq", "mistral", "cohere", "bedrock", "huggingface", "mcp", "fastmcp", "logfire"], specifier = "==1.93.0" },
+    { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "google", "vertexai", "groq", "mistral", "cohere", "bedrock", "huggingface", "mcp", "logfire"], specifier = "==1.100.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "textual", specifier = "==8.2.4" },
@@ -2689,7 +2716,7 @@ email = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.93.0"
+version = "1.100.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -2701,9 +2728,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/44/438dd99c7d044094037e767dab969d704232aab73e4fffd9f9a1f69bded9/pydantic_ai_slim-1.93.0.tar.gz", hash = "sha256:977364ecd3b6a2201e25d917f4efe80895210e44e66cb6983e1fc0477c78910b", size = 639585, upload-time = "2026-05-09T00:23:25.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/db/3eb296369e3001f82d7552060c3811307809954b7c7ec30499f383d3c87a/pydantic_ai_slim-1.100.0.tar.gz", hash = "sha256:cc755c7970b2e041764b9d2f74d50cbad3cf7989b14cdbf62d356f25eb2a1222", size = 726289, upload-time = "2026-05-21T04:04:59.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/67/bbfa2eda2493de6027e3322bccc676c8a7062dc5fe89d68cacf9e50889ce/pydantic_ai_slim-1.93.0-py3-none-any.whl", hash = "sha256:6733e3f19c83f4121fb9fe42aee918bd8f402ce670a519ecc898f108378fadb7", size = 804814, upload-time = "2026-05-09T00:23:17.122Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a6/164b070c59f7c69e81cb5fd38225da24c4587a8fe629af49c72709182ffc/pydantic_ai_slim-1.100.0-py3-none-any.whl", hash = "sha256:422a721b7a7157daff749a6eec9a4ba2e3e7efc28ae5a2bdfe468529eaf81aaf", size = 901788, upload-time = "2026-05-21T04:04:49.147Z" },
 ]
 
 [package.optional-dependencies]
@@ -2715,9 +2742,6 @@ bedrock = [
 ]
 cohere = [
     { name = "cohere", marker = "sys_platform != 'emscripten'" },
-]
-fastmcp = [
-    { name = "fastmcp" },
 ]
 google = [
     { name = "google-genai" },
@@ -2732,7 +2756,7 @@ logfire = [
     { name = "logfire", extra = ["httpx"] },
 ]
 mcp = [
-    { name = "mcp" },
+    { name = "fastmcp-slim", extra = ["client"] },
 ]
 mistral = [
     { name = "mistralai" },
@@ -2864,7 +2888,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.93.0"
+version = "1.100.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2872,9 +2896,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/4addcd3c9d06fbdf6c0776026d8a5b87e7ebb17c9896ac2452e714bb17c6/pydantic_graph-1.93.0.tar.gz", hash = "sha256:17effd900200aa7b72ec0509a79f36d3e161c2a6ef02dda6285a381e867ab195", size = 59250, upload-time = "2026-05-09T00:23:28.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/8b/eee672fa01eec3ea34e7d8962d54aa16d658ad0723466122a7ba2828caa1/pydantic_graph-1.100.0.tar.gz", hash = "sha256:7651fa6ccce9d88a35b1d2cfe79d5d1dbb2415457503009195014bf31f6075bd", size = 62559, upload-time = "2026-05-21T04:05:01.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/bc/5f9eb611c6b9315fb0c6ae58bb82a63d9d9f17340b6c8778319261593fbb/pydantic_graph-1.93.0-py3-none-any.whl", hash = "sha256:ef1b0dcd55a6b5a3544de53a9594216ee8f51ac26bf4be79f7ef310747be598a", size = 73066, upload-time = "2026-05-09T00:23:20.847Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/12/21d6a68743229553c8ba9ca19da73c2d7e18dc6f8fbfd56c8c12c5587cb6/pydantic_graph-1.100.0-py3-none-any.whl", hash = "sha256:ba0b0a70bfd320b58b7012614b857f4b12dbb95b233da7127a6ff973c03d24e7", size = 80101, upload-time = "2026-05-21T04:04:53.635Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2182,7 +2182,7 @@ wheels = [
 
 [[package]]
 name = "oterm"
-version = "0.17.2"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosql" },

--- a/uv.lock
+++ b/uv.lock
@@ -786,23 +786,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cyclopts"
-version = "4.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "docstring-parser" },
-    { name = "rich" },
-    { name = "rich-rst" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/fa/eff8f1abae783bade9b5e9bafafd0040d4dbf51988f9384bfdc0326ba1fc/cyclopts-4.11.0.tar.gz", hash = "sha256:1ffcb9990dbd56b90da19980d31596de9e99019980a215a5d76cf88fe452e94d", size = 170690, upload-time = "2026-04-23T00:23:36.858Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/37/197db187c260d24d4be1f09d427f59f3fb9a89bcf1354e23865c7bff7607/cyclopts-4.11.0-py3-none-any.whl", hash = "sha256:34318e3823b44b5baa754a5e37ec70a5c17dc81c65e4295ed70e17bc1aeae50d", size = 208494, upload-time = "2026-04-23T00:23:34.948Z" },
-]
-
-[[package]]
 name = "deepmerge"
 version = "2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -845,15 +828,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
-]
-
-[[package]]
-name = "docutils"
-version = "0.22.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -971,39 +945,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900, upload-time = "2026-04-24T14:37:29.233Z" },
     { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637, upload-time = "2026-04-24T14:37:31.472Z" },
     { url = "https://files.pythonhosted.org/packages/32/f1/f21bd5319113e89ceceed2df840df21e9c5150d181db74b6ba80400f9f48/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:afede7324822800e4f90e96b9514188a237a60f35e8e7a10b2129c10c78f6e4d", size = 3356664, upload-time = "2026-04-24T14:37:34.231Z" },
-]
-
-[[package]]
-name = "fastmcp"
-version = "3.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "authlib" },
-    { name = "cyclopts" },
-    { name = "exceptiongroup" },
-    { name = "griffelib" },
-    { name = "httpx" },
-    { name = "jsonref" },
-    { name = "jsonschema-path" },
-    { name = "mcp" },
-    { name = "openapi-pydantic" },
-    { name = "opentelemetry-api" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
-    { name = "pyperclip" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "uncalled-for" },
-    { name = "uvicorn" },
-    { name = "watchfiles" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
 ]
 
 [[package]]
@@ -1603,15 +1544,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jsonref"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
-]
-
-[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1624,20 +1556,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
-]
-
-[[package]]
-name = "jsonschema-path"
-version = "0.4.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pathable" },
-    { name = "pyyaml" },
-    { name = "referencing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/d5/4e96c44f6c1ea3d812cf5391d81a4f5abaa540abf8d04ecd7f66e0ed11df/jsonschema_path-0.4.5-py3-none-any.whl", hash = "sha256:7d77a2c3f3ec569a40efe5c5f942c44c1af2a6f96fe0866794c9ef5b8f87fd65", size = 19368, upload-time = "2026-03-03T09:56:45.39Z" },
 ]
 
 [[package]]
@@ -2141,18 +2059,6 @@ wheels = [
 ]
 
 [[package]]
-name = "openapi-pydantic"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
-]
-
-[[package]]
 name = "opentelemetry-api"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2281,7 +2187,6 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosql" },
     { name = "aiosqlite" },
-    { name = "fastmcp" },
     { name = "ollama" },
     { name = "packaging" },
     { name = "pillow" },
@@ -2316,7 +2221,6 @@ dev = [
 requires-dist = [
     { name = "aiosql", specifier = "==15.0" },
     { name = "aiosqlite", specifier = "==0.22.1" },
-    { name = "fastmcp", specifier = "==3.2.4" },
     { name = "ollama", specifier = "==0.6.2" },
     { name = "packaging", specifier = "==26.2" },
     { name = "pillow", specifier = "==12.2.0" },
@@ -2354,15 +2258,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
-]
-
-[[package]]
-name = "pathable"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
 ]
 
 [[package]]
@@ -2955,15 +2850,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyperclip"
-version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
-]
-
-[[package]]
 name = "pyreadline3"
 version = "3.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3355,19 +3241,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
-name = "rich-rst"
-version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "rich" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
 ]
 
 [[package]]
@@ -4045,15 +3918,6 @@ wheels = [
 ]
 
 [[package]]
-name = "uncalled-for"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
-]
-
-[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4090,109 +3954,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
-]
-
-[[package]]
-name = "watchfiles"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/1a/206e8cf2dd86fddf939165a57b4df61607a1e0add2785f170a3f616b7d9f/watchfiles-1.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:eef58232d32daf2ac67f42dea51a2c80f0d03379075d44a587051e63cc2e368c", size = 407318, upload-time = "2025-10-14T15:04:18.753Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/0f/abaf5262b9c496b5dad4ed3c0e799cbecb1f8ea512ecb6ddd46646a9fca3/watchfiles-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03fa0f5237118a0c5e496185cafa92878568b652a2e9a9382a5151b1a0380a43", size = 394478, upload-time = "2025-10-14T15:04:20.297Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/04/9cc0ba88697b34b755371f5ace8d3a4d9a15719c07bdc7bd13d7d8c6a341/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca65483439f9c791897f7db49202301deb6e15fe9f8fe2fed555bf986d10c31", size = 449894, upload-time = "2025-10-14T15:04:21.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/9c/eda4615863cd8621e89aed4df680d8c3ec3da6a4cf1da113c17decd87c7f/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0ab1c1af0cb38e3f598244c17919fb1a84d1629cc08355b0074b6d7f53138ac", size = 459065, upload-time = "2025-10-14T15:04:22.795Z" },
-    { url = "https://files.pythonhosted.org/packages/84/13/f28b3f340157d03cbc8197629bc109d1098764abe1e60874622a0be5c112/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bc570d6c01c206c46deb6e935a260be44f186a2f05179f52f7fcd2be086a94d", size = 488377, upload-time = "2025-10-14T15:04:24.138Z" },
-    { url = "https://files.pythonhosted.org/packages/86/93/cfa597fa9389e122488f7ffdbd6db505b3b915ca7435ecd7542e855898c2/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e84087b432b6ac94778de547e08611266f1f8ffad28c0ee4c82e028b0fc5966d", size = 595837, upload-time = "2025-10-14T15:04:25.057Z" },
-    { url = "https://files.pythonhosted.org/packages/57/1e/68c1ed5652b48d89fc24d6af905d88ee4f82fa8bc491e2666004e307ded1/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:620bae625f4cb18427b1bb1a2d9426dc0dd5a5ba74c7c2cdb9de405f7b129863", size = 473456, upload-time = "2025-10-14T15:04:26.497Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/dc/1a680b7458ffa3b14bb64878112aefc8f2e4f73c5af763cbf0bd43100658/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:544364b2b51a9b0c7000a4b4b02f90e9423d97fbbf7e06689236443ebcad81ab", size = 455614, upload-time = "2025-10-14T15:04:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a5/3d782a666512e01eaa6541a72ebac1d3aae191ff4a31274a66b8dd85760c/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbe1ef33d45bc71cf21364df962af171f96ecaeca06bd9e3d0b583efb12aec82", size = 630690, upload-time = "2025-10-14T15:04:28.495Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/73/bb5f38590e34687b2a9c47a244aa4dd50c56a825969c92c9c5fc7387cea1/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1a0bb430adb19ef49389e1ad368450193a90038b5b752f4ac089ec6942c4dff4", size = 622459, upload-time = "2025-10-14T15:04:29.491Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ac/c9bb0ec696e07a20bd58af5399aeadaef195fb2c73d26baf55180fe4a942/watchfiles-1.1.1-cp310-cp310-win32.whl", hash = "sha256:3f6d37644155fb5beca5378feb8c1708d5783145f2a0f1c4d5a061a210254844", size = 272663, upload-time = "2025-10-14T15:04:30.435Z" },
-    { url = "https://files.pythonhosted.org/packages/11/a0/a60c5a7c2ec59fa062d9a9c61d02e3b6abd94d32aac2d8344c4bdd033326/watchfiles-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a36d8efe0f290835fd0f33da35042a1bb5dc0e83cbc092dcf69bce442579e88e", size = 287453, upload-time = "2025-10-14T15:04:31.53Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
-    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
-    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
-    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
-    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
-    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
-    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
-    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
-    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
-    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
-    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
-    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
-    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
-    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
-    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
-    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
-    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
-    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
-    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
-    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
-    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
-    { url = "https://files.pythonhosted.org/packages/83/4e/b87b71cbdfad81ad7e83358b3e447fedd281b880a03d64a760fe0a11fc2e/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b495de0bb386df6a12b18335a0285dda90260f51bdb505503c02bcd1ce27a8b", size = 458413, upload-time = "2025-10-14T15:06:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **MCP layer migrated to pydantic-ai 1.100's `MCPToolset`.** Replaces the deprecated `MCPServer*` classes ahead of their removal in pydantic-ai 2.0. The runtime now uses FastMCP's client under the hood (via `fastmcp-slim[client]`). Existing `mcpServers` config entries (stdio, HTTP, SSE, env-var substitution, WebSocket rejection) keep working unchanged.
- **pydantic-ai 1.100 deprecations cleared end-to-end.** Image generation now registers via `capabilities=[NativeTool(...)]`. Streaming reads `run.usage` as a property. Tool-call parts use `NativeToolCallPart` / `NativeToolReturnPart`. Provider ids align with pydantic-ai's new namespace: `openai` → `openai-chat`, `google-gla` → `google`, `google-vertex` → `google-cloud`. Existing chats are rewritten in place by a one-shot store migration (v0.18.0).
