### PR TITLE
Forward the thinking toggle to Ollama models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Thinking can now be disabled for Ollama models.** ([#312](https://github.com/ggozad/oterm/issues/312)) Ollama routes through pydantic-ai's `OllamaProvider`, and thinking-capable models are marked `supports_thinking` in their profile, so the chat's thinking toggle reaches Ollama as `reasoning_effort` instead of being silently dropped.
+
 ## [0.18.0] - 2026-05-22
 
 ### Changed

--- a/src/oterm/agent.py
+++ b/src/oterm/agent.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import Any
 
 from pydantic_ai import Agent
@@ -5,11 +6,13 @@ from pydantic_ai import Tool as PydanticTool
 from pydantic_ai.capabilities import AbstractCapability, NativeTool
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
 from pydantic_ai.native_tools import ImageGenerationTool
+from pydantic_ai.providers.ollama import OllamaProvider
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.toolsets import AbstractToolset
 
 from oterm.config import envConfig
+from oterm.providers.capabilities import get_capabilities
 from oterm.providers.ollama import openai_compat_base_url
 from oterm.providers.settings import get_supported_setting_keys
 
@@ -55,12 +58,21 @@ def get_agent(
     pydantic_model: OpenAIChatModel | OpenAIResponsesModel | str
     capabilities: list[AbstractCapability[None]] = []
     if provider == "ollama":
+        ollama_provider = OllamaProvider(
+            base_url=openai_compat_base_url(),
+            api_key=envConfig.OLLAMA_API_KEY or "ollama",
+        )
+        # Ollama's pydantic-ai profiles don't mark thinking-capable models as
+        # supporting thinking, so the unified `thinking` setting is dropped
+        # before the request and thinking can't be turned off. Ollama itself
+        # reports the capability, so trust that and let the setting through.
+        profile = ollama_provider.model_profile(model)
+        if profile is not None and get_capabilities(provider, model).supports_thinking:
+            profile = replace(profile, supports_thinking=True)
         pydantic_model = OpenAIChatModel(
             model_name=model,
-            provider=OpenAIProvider(
-                base_url=openai_compat_base_url(),
-                api_key=envConfig.OLLAMA_API_KEY or "ollama",
-            ),
+            provider=ollama_provider,
+            profile=profile,
         )
     elif provider == "openai-responses":
         pydantic_model = OpenAIResponsesModel(model_name=model)

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,10 +1,30 @@
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.ollama import OllamaProvider
 from pydantic_ai.providers.openai import OpenAIProvider
 
 from oterm.agent import _build_model_settings, get_agent
 from oterm.providers import UNRESOLVED_API_KEY
+from oterm.providers.capabilities import ModelCapabilities
+
+
+@pytest.fixture
+def ollama_thinking(monkeypatch):
+    """Stub Ollama capability detection so get_agent stays offline."""
+
+    def _set(supports_thinking: bool) -> None:
+        import oterm.agent as agent_mod
+
+        monkeypatch.setattr(
+            agent_mod,
+            "get_capabilities",
+            lambda provider, model: ModelCapabilities(
+                supports_thinking=supports_thinking
+            ),
+        )
+
+    return _set
 
 
 class TestBuildModelSettings:
@@ -97,26 +117,28 @@ class TestBuildModelSettings:
 
 
 class TestGetAgent:
-    def test_ollama_provider(self, monkeypatch):
+    def test_ollama_provider(self, monkeypatch, ollama_thinking):
         import oterm.config
 
+        ollama_thinking(False)
         monkeypatch.setattr(
             oterm.config.envConfig, "OLLAMA_URL", "http://localhost:11434"
         )
         agent = get_agent(provider="ollama", model="llama3")
         assert isinstance(agent, Agent)
         assert isinstance(agent.model, OpenAIChatModel)
-        assert isinstance(agent.model._provider, OpenAIProvider)
+        assert isinstance(agent.model._provider, OllamaProvider)
         assert (
             str(agent.model.client.base_url).rstrip("/") == "http://localhost:11434/v1"
         )
 
-    def test_ollama_provider_w_api_key(self, monkeypatch):
+    def test_ollama_provider_w_api_key(self, monkeypatch, ollama_thinking):
         import oterm.config
 
         OLLAMA_URL = "https://ollama.example.com"
         OLLAMA_API_KEY = "TEST_KEY"
 
+        ollama_thinking(False)
         monkeypatch.setattr(
             oterm.config.envConfig,
             "OLLAMA_URL",
@@ -126,9 +148,37 @@ class TestGetAgent:
         agent = get_agent(provider="ollama", model="llama3")
         assert isinstance(agent, Agent)
         assert isinstance(agent.model, OpenAIChatModel)
-        assert isinstance(agent.model._provider, OpenAIProvider)
+        assert isinstance(agent.model._provider, OllamaProvider)
         assert str(agent.model.client.base_url).rstrip("/") == f"{OLLAMA_URL}/v1"
         assert agent.model.client.api_key == OLLAMA_API_KEY
+
+    def test_ollama_thinking_capable_model_enables_thinking_in_profile(
+        self, monkeypatch, ollama_thinking
+    ):
+        """A thinking-capable Ollama model must report supports_thinking so
+        pydantic-ai forwards the unified thinking setting (and can disable it)."""
+        import oterm.config
+
+        ollama_thinking(True)
+        monkeypatch.setattr(
+            oterm.config.envConfig, "OLLAMA_URL", "http://localhost:11434"
+        )
+        agent = get_agent(provider="ollama", model="qwen3.6")
+        assert isinstance(agent.model, OpenAIChatModel)
+        assert agent.model.profile.supports_thinking is True
+
+    def test_ollama_non_thinking_model_leaves_thinking_disabled_in_profile(
+        self, monkeypatch, ollama_thinking
+    ):
+        import oterm.config
+
+        ollama_thinking(False)
+        monkeypatch.setattr(
+            oterm.config.envConfig, "OLLAMA_URL", "http://localhost:11434"
+        )
+        agent = get_agent(provider="ollama", model="devstral")
+        assert isinstance(agent.model, OpenAIChatModel)
+        assert agent.model.profile.supports_thinking is False
 
     def test_openai_responses_provider_enables_image_generation_tool(self, monkeypatch):
         from pydantic_ai.models.openai import OpenAIResponsesModel


### PR DESCRIPTION
- **Thinking can now be disabled for Ollama models.** ([#312](https://github.com/ggozad/oterm/issues/312)) Ollama routes through pydantic-ai's `OllamaProvider`, and thinking-capable models are marked `supports_thinking` in their profile, so the chat's thinking toggle reaches Ollama as `reasoning_effort` instead of being silently dropped.

Closes #312 