### PR TITLE
Bind Ctrl+t for session-only thinking toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Session-only thinking toggle bound to <kbd>Ctrl</kbd>+<kbd>t</kbd> (`toggle.thinking`), with a matching `Toggle thinking` command palette entry. ([#313](https://github.com/ggozad/oterm/issues/313))
+
 ### Fixed
 
 - **Thinking can now be disabled for Ollama models.** ([#312](https://github.com/ggozad/oterm/issues/312)) Ollama routes through pydantic-ai's `OllamaProvider`, and thinking-capable models are marked `supports_thinking` in their profile, so the chat's thinking toggle reaches Ollama as `reasoning_effort` instead of being silently dropped.

--- a/docs/app_config.md
+++ b/docs/app_config.md
@@ -26,6 +26,7 @@ A complete example showing every supported key:
     "next.chat": "ctrl+tab",
     "prev.chat": "ctrl+shift+tab",
     "new.chat": "ctrl+n",
+    "toggle.thinking": "ctrl+t",
     "show.logs": "ctrl+l",
     "quit": "ctrl+q",
     "newline": "shift+enter",
@@ -65,6 +66,7 @@ Sane defaults are provided, but terminal emulators and shells will sometimes int
 | `next.chat` | `ctrl+tab`         | Switch to the next chat tab.                                            |
 | `prev.chat` | `ctrl+shift+tab`   | Switch to the previous chat tab.                                        |
 | `new.chat`  | `ctrl+n`           | Open the new-chat dialog.                                               |
+| `toggle.thinking` | `ctrl+t`     | Turn thinking mode on or off for the current session (not persisted).  |
 | `show.logs` | `ctrl+l`           | Open the log viewer.                                                    |
 | `quit`      | `ctrl+q`           | Quit `oterm`.                                                           |
 | `newline`   | `shift+enter`      | Insert a newline in the prompt. `ctrl+m` is also accepted as a fallback for terminals that can't distinguish `shift+enter` from `enter`, and is not configurable. |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,6 +3,7 @@ By pressing <kbd>^ Ctrl</kbd>+<kbd>p</kbd> you can access the command palette fr
 
 * `New chat` - create a new chat session
 * `Edit chat parameters` - edit the current chat session (change system prompt, tools, parameters, or thinking)
+* `Toggle thinking` - turn thinking mode on or off for the current session (not persisted)
 * `Rename chat` - rename the current chat session
 * `Export chat` - export the current chat session as markdown
 * `Delete chat` - delete the current chat session
@@ -26,6 +27,7 @@ The following keyboard shortcuts are supported:
 * <kbd>^ Ctrl</kbd>+<kbd>l</kbd> - show logs
 
 * <kbd>^ Ctrl</kbd>+<kbd>n</kbd> - open a new chat
+* <kbd>^ Ctrl</kbd>+<kbd>t</kbd> - toggle thinking mode for the current session (not persisted)
 
 * <kbd>^ Ctrl</kbd>+<kbd>Tab</kbd> - open the next chat
 * <kbd>^ Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Tab</kbd> - open the previous chat

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -35,6 +35,7 @@ class OTerm(App):
             priority=True,
         ),
         Binding("ctrl+n", "new_chat", "new chat", id="new.chat"),
+        Binding("ctrl+t", "toggle_thinking", "toggle thinking", id="toggle.thinking"),
         Binding("ctrl+l", "show_logs", "show logs", id="show.logs"),
         Binding("ctrl+q", "quit", "quit", id="quit"),
     ]
@@ -46,6 +47,11 @@ class OTerm(App):
             "Edit chat parameters",
             "Allows to redefine model parameters and system prompt",
             self.action_edit_chat,
+        )
+        yield SystemCommand(
+            "Toggle thinking",
+            "Turns thinking mode on or off for the current chat",
+            self.action_toggle_thinking,
         )
         yield SystemCommand(
             "Rename chat", "Renames the current chat", self.action_rename_chat
@@ -124,6 +130,13 @@ class OTerm(App):
             return
         chat = tabs.active_pane.query_one(ChatContainer)
         chat.action_edit_chat()
+
+    async def action_toggle_thinking(self) -> None:
+        tabs = self.query_one(TabbedContent)
+        if tabs.active_pane is None:
+            return
+        chat = tabs.active_pane.query_one(ChatContainer)
+        chat.action_toggle_thinking()
 
     async def action_rename_chat(self) -> None:
         tabs = self.query_one(TabbedContent)

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -62,6 +62,7 @@ from oterm.app.widgets.image import ImageAdded
 from oterm.app.widgets.prompt import IMAGE_TOKEN_RE, FlexibleInput, PostableTextArea
 from oterm.config import envConfig
 from oterm.log import log
+from oterm.providers.capabilities import get_capabilities
 from oterm.store.store import Store
 from oterm.tools import builtin_tools
 from oterm.tools.mcp.setup import mcp_servers, mcp_tool_meta
@@ -522,6 +523,21 @@ class ChatContainer(Widget):
         self.system = self.chat_model.system
 
         self._rebuild_agent()
+
+    def action_toggle_thinking(self) -> None:
+        """Toggle thinking for the current session only; not persisted."""
+        if not get_capabilities(
+            self.chat_model.provider, self.chat_model.model
+        ).supports_thinking:
+            self.app.notify(
+                f"{self.chat_model.model} does not support thinking.",
+                severity="warning",
+            )
+            return
+
+        self.chat_model.thinking = not self.chat_model.thinking
+        self._rebuild_agent()
+        self.app.notify(f"Thinking {'on' if self.chat_model.thinking else 'off'}.")
 
     @work
     async def action_rename_chat(self) -> None:

--- a/tests/app/test_oterm_app.py
+++ b/tests/app/test_oterm_app.py
@@ -390,6 +390,30 @@ class TestActionDelegates:
             await pilot.pause()
             assert called == [True]
 
+    async def test_toggle_thinking_delegates(
+        self, tmp_data_dir, app_config, stub_network, store, monkeypatch
+    ):
+        from oterm.app.oterm import OTerm
+        from oterm.app.widgets.chat import ChatContainer
+
+        app_config.set("splash-screen", False)
+        cm = ChatModel(name="c", model="m")
+        cm.id = await store.save_chat(cm)
+
+        app = OTerm()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            called: list[bool] = []
+
+            def spy(self):
+                called.append(True)
+
+            monkeypatch.setattr(ChatContainer, "action_toggle_thinking", spy)
+            await app.action_toggle_thinking()
+            await pilot.pause()
+            assert called == [True]
+
     async def test_regenerate_last_message_delegates(
         self, tmp_data_dir, app_config, stub_network, store, monkeypatch
     ):
@@ -427,6 +451,7 @@ class TestActionDelegates:
 
             # None of these should raise.
             await app.action_edit_chat()
+            await app.action_toggle_thinking()
             await app.action_rename_chat()
             await app.action_export_chat()
             await app.action_regenerate_last_message()
@@ -654,6 +679,28 @@ class TestKeymap:
             await pilot.pause()
             calls.clear()  # ignore the on_mount auto-new-chat call
             await pilot.press("f5")
+            await pilot.pause()
+            assert calls == [True]
+
+    async def test_keymap_remaps_toggle_thinking_binding(
+        self, tmp_data_dir, app_config, stub_network, monkeypatch
+    ):
+        import oterm.app.oterm as oterm_mod
+
+        calls: list[bool] = []
+
+        async def spy(self):
+            calls.append(True)
+
+        monkeypatch.setattr(oterm_mod.OTerm, "action_toggle_thinking", spy)
+
+        app_config.set("splash-screen", False)
+        app_config.set("keymap", {"toggle.thinking": "f6"})
+
+        app = oterm_mod.OTerm()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("f6")
             await pilot.pause()
             assert calls == [True]
 

--- a/tests/widgets/test_chat_container.py
+++ b/tests/widgets/test_chat_container.py
@@ -661,6 +661,123 @@ class TestEditChat:
             assert container.chat_model.model == original_model
 
 
+class TestToggleThinking:
+    async def test_toggle_enables_thinking_for_session_only(
+        self, store, chat_model, monkeypatch
+    ):
+        from oterm.app.widgets import chat as chat_module
+        from oterm.providers.capabilities import ModelCapabilities
+
+        chat_id = await store.save_chat(chat_model)
+        chat_model.id = chat_id
+
+        monkeypatch.setattr(
+            chat_module,
+            "get_capabilities",
+            lambda provider, model: ModelCapabilities(supports_thinking=True),
+        )
+
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            assert container.chat_model.thinking is False
+
+            container.action_toggle_thinking()
+            await pilot.pause()
+
+            assert container.chat_model.thinking is True
+            assert any("Thinking on" in n.message for n in _notifications(app))
+
+            # Session-only: the stored chat is untouched.
+            reloaded = await store.get_chat(chat_id)
+            assert reloaded is not None and reloaded.thinking is False
+
+    async def test_toggle_disables_thinking_for_session_only(
+        self, store, chat_model, monkeypatch
+    ):
+        from oterm.app.widgets import chat as chat_module
+        from oterm.providers.capabilities import ModelCapabilities
+
+        chat_model.thinking = True
+        chat_id = await store.save_chat(chat_model)
+        chat_model.id = chat_id
+
+        monkeypatch.setattr(
+            chat_module,
+            "get_capabilities",
+            lambda provider, model: ModelCapabilities(supports_thinking=True),
+        )
+
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            container.action_toggle_thinking()
+            await pilot.pause()
+
+            assert container.chat_model.thinking is False
+            assert any("Thinking off" in n.message for n in _notifications(app))
+
+            reloaded = await store.get_chat(chat_id)
+            assert reloaded is not None and reloaded.thinking is True
+
+    async def test_toggle_rebuilds_agent_with_new_thinking(
+        self, store, chat_model, monkeypatch
+    ):
+        from oterm.app.widgets import chat as chat_module
+        from oterm.providers.capabilities import ModelCapabilities
+
+        chat_id = await store.save_chat(chat_model)
+        chat_model.id = chat_id
+
+        monkeypatch.setattr(
+            chat_module,
+            "get_capabilities",
+            lambda provider, model: ModelCapabilities(supports_thinking=True),
+        )
+
+        thinking_seen: list[bool] = []
+
+        def fake_get_agent(*args, thinking, **kwargs):
+            thinking_seen.append(thinking)
+            return None
+
+        monkeypatch.setattr(chat_module, "get_agent", fake_get_agent)
+
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            thinking_seen.clear()
+            container.action_toggle_thinking()
+            await pilot.pause()
+            assert thinking_seen == [True]
+
+    async def test_toggle_on_unsupported_model_notifies_and_noops(
+        self, store, chat_model, monkeypatch
+    ):
+        from oterm.app.widgets import chat as chat_module
+        from oterm.providers.capabilities import ModelCapabilities
+
+        chat_id = await store.save_chat(chat_model)
+        chat_model.id = chat_id
+
+        monkeypatch.setattr(
+            chat_module,
+            "get_capabilities",
+            lambda provider, model: ModelCapabilities(supports_thinking=False),
+        )
+
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            container.action_toggle_thinking()
+            await pilot.pause()
+
+            assert any(
+                "does not support thinking" in n.message for n in _notifications(app)
+            )
+            assert container.chat_model.thinking is False
+
+
 class TestRenameChat:
     async def test_rename_chat_updates_store_and_notifies(
         self, store, chat_model, monkeypatch


### PR DESCRIPTION
- Session-only thinking toggle bound to <kbd>Ctrl</kbd>+<kbd>t</kbd> (`toggle.thinking`), with a matching `Toggle thinking` command palette entry. 

Closes #313 