### PR TITLE
Label attached images with their sniffed media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - pydantic-ai bumped to 2.17.0.
 
+### Fixed
+
+- Attached images are sent with their actual media type instead of always `image/png`; unrecognizable image data is skipped.
+
 ## [0.20.0] - 2026-06-30
 
 ### Added

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -83,7 +83,11 @@ def _decode_image(b64: str) -> BinaryContent | None:
         data = base64.b64decode(b64, validate=True)
     except (binascii.Error, ValueError):
         return None
-    return BinaryContent(data=data, media_type="image/png")
+    try:
+        fmt = PILImage.open(BytesIO(data)).format or "PNG"
+    except UnidentifiedImageError:
+        return None
+    return BinaryContent(data=data, media_type=f"image/{fmt.lower()}")
 
 
 def build_user_prompt(

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,7 +1,18 @@
 """Shared test helpers."""
 
 import asyncio
+from base64 import b64encode
 from collections.abc import Callable
+from io import BytesIO
+
+import PIL.Image as PILImage
+
+
+def image_b64(fmt: str = "PNG") -> str:
+    """Base64 of a real 1x1 image in the given format."""
+    buffer = BytesIO()
+    PILImage.new("RGB", (1, 1)).save(buffer, format=fmt)
+    return b64encode(buffer.getvalue()).decode()
 
 
 async def wait_until(

--- a/tests/agent/test_streaming.py
+++ b/tests/agent/test_streaming.py
@@ -1,4 +1,3 @@
-import base64
 from collections.abc import AsyncIterator
 
 from pydantic_ai import Agent, Tool
@@ -19,6 +18,7 @@ from pydantic_ai.models.function import (
 
 from oterm.app.widgets.chat import ChatContainer
 from oterm.types import ChatModel
+from tests._helpers import image_b64
 from tests._stream_helpers import make_file_aware_agent
 
 
@@ -250,8 +250,9 @@ class TestImagePrompt:
         c = _container()
         _install_stream_agent(c, stream_fn)
 
-        img_b64 = base64.b64encode(b"\x89PNG\r\n").decode()
-        user_prompt, _ = build_user_prompt("what is this?", [img_b64])
+        img_b64 = image_b64()
+        user_prompt, skipped = build_user_prompt("what is this?", [img_b64])
+        assert skipped == 0
         chunks = await _collect(c.stream_agent(user_prompt))
         text = "".join(p.content_delta for p in chunks if isinstance(p, TextPartDelta))
         assert text == "see this"

--- a/tests/widgets/test_chat_container.py
+++ b/tests/widgets/test_chat_container.py
@@ -23,7 +23,7 @@ from oterm.app.widgets.chat import (
 )
 from oterm.app.widgets.prompt import FlexibleInput
 from oterm.types import ChatModel, MessageModel
-from tests._helpers import wait_until
+from tests._helpers import image_b64, wait_until
 
 
 class _Host(App):
@@ -358,7 +358,7 @@ class TestImages:
             container = app.query_one(ChatContainer)
             container.agent = Agent(FunctionModel(stream_function=stream_fn))
 
-            good = base64.b64encode(b"\x89PNG\r\n").decode()
+            good = image_b64()
             bad = "not-valid-base64!!"
 
             user_prompt, skipped = build_user_prompt("look", [good, bad])
@@ -375,6 +375,32 @@ class TestImages:
             await pilot.pause()
 
 
+class TestDecodeImage:
+    def test_jpeg_labeled_jpeg(self):
+        from oterm.app.widgets.chat import _decode_image
+
+        content = _decode_image(image_b64("JPEG"))
+        assert content is not None
+        assert content.media_type == "image/jpeg"
+
+    def test_png_labeled_png(self):
+        from oterm.app.widgets.chat import _decode_image
+
+        content = _decode_image(image_b64("PNG"))
+        assert content is not None
+        assert content.media_type == "image/png"
+
+    def test_non_image_bytes_return_none(self):
+        from oterm.app.widgets.chat import _decode_image
+
+        assert _decode_image(base64.b64encode(b"not an image").decode()) is None
+
+    def test_invalid_b64_returns_none(self):
+        from oterm.app.widgets.chat import _decode_image
+
+        assert _decode_image("not-valid!!") is None
+
+
 class TestBuildUserPrompt:
     def test_no_tokens_no_images_returns_text(self):
         from oterm.app.widgets.chat import build_user_prompt
@@ -386,7 +412,7 @@ class TestBuildUserPrompt:
 
         from oterm.app.widgets.chat import build_user_prompt
 
-        good = base64.b64encode(b"\x89PNG\r\n").decode()
+        good = image_b64()
         prompt, skipped = build_user_prompt("describe", [good])
         assert skipped == 0
         assert isinstance(prompt, list)
@@ -398,7 +424,7 @@ class TestBuildUserPrompt:
 
         from oterm.app.widgets.chat import build_user_prompt
 
-        good = base64.b64encode(b"\x89PNG\r\n").decode()
+        good = image_b64()
         prompt, skipped = build_user_prompt("see [Image #1] please", [good])
         assert skipped == 0
         assert isinstance(prompt, list)
@@ -411,8 +437,8 @@ class TestBuildUserPrompt:
 
         from oterm.app.widgets.chat import build_user_prompt
 
-        good1 = base64.b64encode(b"\x89PNG\r\n1").decode()
-        good2 = base64.b64encode(b"\x89PNG\r\n2").decode()
+        good1 = image_b64("PNG")
+        good2 = image_b64("JPEG")
         prompt, skipped = build_user_prompt("[Image #2] only", [good1, good2])
         assert skipped == 0
         assert isinstance(prompt, list)
@@ -446,7 +472,7 @@ class TestBuildUserPrompt:
 
         from oterm.app.widgets.chat import build_user_prompt
 
-        good = base64.b64encode(b"\x89PNG\r\n").decode()
+        good = image_b64()
         prompt, skipped = build_user_prompt("see [Image #1]", [good])
         assert skipped == 0
         assert isinstance(prompt, list)
@@ -462,7 +488,7 @@ class TestPydanticHistoryRebuild:
 
         chat_id = await store.save_chat(chat_model)
         chat_model.id = chat_id
-        good = base64.b64encode(b"\x89PNG\r\n").decode()
+        good = image_b64()
         msg = MessageModel(
             chat_id=chat_id,
             role="user",
@@ -491,7 +517,7 @@ class TestPydanticHistoryRebuild:
 
         chat_id = await store.save_chat(chat_model)
         chat_model.id = chat_id
-        good = base64.b64encode(b"\x89PNG\r\n").decode()
+        good = image_b64()
         msg = MessageModel(
             chat_id=chat_id,
             role="user",


### PR DESCRIPTION
`_decode_image` hardcoded `image/png` while `ImageSelect` re-encodes every picked image to JPEG. Sniff the format with PIL and skip data that is not a recognizable image.