### PR TITLE
Qualify MCP tool names by server

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        entry: uvx ty check
+        entry: uv run ty check
         language: system
         types: [python]
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Unreleased]
 
+### Fixed
+
+- MCP tool names are qualified by server as `{server}_{tool}`, so two servers exporting the same tool name no longer conflict and each is selectable independently. The `0.22.0` store upgrade rewrites existing chat selections for servers reachable at that launch. ([#321](https://github.com/ggozad/oterm/issues/321))
+- MCP server names that providers would reject as part of a tool name are refused at config load, and tools whose qualified name exceeds 64 characters are skipped.
+
 ## [0.21.0] - 2026-07-25
 
 ### Added

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -17,6 +17,10 @@ Add MCP servers under the `mcpServers` key in `oterm`'s [config.json](../app_con
 
 [MCP tools](https://modelcontextprotocol.io/docs/concepts/tools) appear in oterm's tool selector and can be enabled per chat.
 
+The model sees each MCP tool as `{server}_{tool}` — the `query_prometheus` tool on a server configured as `grafana` is presented as `grafana_query_prometheus`. Two servers can therefore export the same tool name, and each is selectable on its own.
+
+Because the server name reaches the model, it may only contain letters, digits, underscores and hyphens — `k8s-lab` is fine, `k8s.lab` is not. A server whose name has other characters is refused when the config loads, and a tool whose qualified name is over 64 characters is skipped; both are reported in the log.
+
 !!! note
     Not all models support tools. For models that don't, the tool selection is disabled.
 

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -14,7 +14,8 @@ from oterm.app.widgets.chat import ChatContainer
 from oterm.app.widgets.empty_state import EmptyState
 from oterm.config import appConfig
 from oterm.store.store import Store
-from oterm.tools.mcp.setup import setup_mcp_servers, teardown_mcp_servers
+from oterm.tools import load_tools
+from oterm.tools.mcp.setup import teardown_mcp_servers
 from oterm.types import ChatModel
 from oterm.utils import is_up_to_date
 
@@ -198,13 +199,6 @@ class OTerm(App):
         screen = LogViewer()
         self.push_screen(screen)
 
-    async def load_tools(self):
-        from oterm.tools import builtin_tools, discover_tools
-
-        builtin_tools.clear()
-        builtin_tools.extend(discover_tools())
-        await setup_mcp_servers()
-
     @work(exclusive=True, group="checks")
     async def perform_checks(self) -> None:
         up_to_date, _, latest = await is_up_to_date()
@@ -216,6 +210,9 @@ class OTerm(App):
 
     async def on_mount(self) -> None:
         self.register_theme(solarized_dark)
+        # Tools load first: the store upgrade that qualifies MCP tool names by
+        # server needs the connected servers' tool lists.
+        await load_tools()
         store = await Store.get_store()
         theme = appConfig.get("theme")
         if theme:  # pragma: no branch
@@ -232,8 +229,6 @@ class OTerm(App):
         keymap = appConfig.get("keymap")
         if keymap:
             self.set_keymap(keymap)
-
-        await self.load_tools()
 
         async def on_splash_done(message) -> None:
             tabs = self.query_one(TabbedContent)

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -159,9 +159,10 @@ def _resolve_tools(tool_names: list[str]):
     """Split selected tool names into pydantic-ai Tool objects, filtered MCP toolsets and capabilities."""
     from pydantic_ai import Tool as PydanticTool
     from pydantic_ai.capabilities import AbstractCapability
-    from pydantic_ai.toolsets import AbstractToolset
+    from pydantic_ai.toolsets import AbstractToolset, PrefixedToolset
 
     from oterm.log import log
+    from oterm.tools import qualified_tool_name
 
     selected = set(tool_names)
     tools: list[PydanticTool] = []
@@ -180,13 +181,18 @@ def _resolve_tools(tool_names: list[str]):
 
     toolsets: list[AbstractToolset[None]] = []
     for server_name, meta in mcp_tool_meta.items():
-        names_on_server = {m["name"] for m in meta}
-        available_names |= names_on_server
-        chosen = selected & names_on_server
+        by_qualified = {
+            qualified_tool_name(server_name, m["name"]): m["name"] for m in meta
+        }
+        available_names |= by_qualified.keys()
+        chosen = {by_qualified[q] for q in selected & by_qualified.keys()}
         if chosen:
             toolsets.append(
-                mcp_servers[server_name].filtered(
-                    lambda _ctx, td, names=chosen: td.name in names
+                PrefixedToolset(
+                    mcp_servers[server_name].filtered(
+                        lambda _ctx, td, names=chosen: td.name in names
+                    ),
+                    server_name,
                 )
             )
 

--- a/src/oterm/app/widgets/tool_select.py
+++ b/src/oterm/app/widgets/tool_select.py
@@ -5,7 +5,7 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Checkbox
 
-from oterm.tools import builtin_tools, known_tool_names
+from oterm.tools import builtin_tools, known_tool_names, qualified_tool_name
 from oterm.tools.capabilities import capability_defs
 from oterm.tools.mcp.setup import mcp_tool_meta
 
@@ -27,7 +27,11 @@ def _all_groups() -> dict[str, list[dict]]:
         ]
     for server_name, metas in mcp_tool_meta.items():
         groups[server_name] = [
-            {"name": m["name"], "description": m["description"]} for m in metas
+            {
+                "name": qualified_tool_name(server_name, m["name"]),
+                "description": m["description"],
+            }
+            for m in metas
         ]
     return groups
 
@@ -98,7 +102,7 @@ class ToolSelector(Widget):
                             yield Checkbox(
                                 id=f"{group}-{meta['name']}",
                                 name=meta["name"],
-                                label=meta["name"],
+                                label=meta["name"].removeprefix(f"{group}_"),
                                 tooltip=meta["description"],
                                 value=meta["name"] in self.selected,
                                 classes="tool",

--- a/src/oterm/cli/oterm.py
+++ b/src/oterm/cli/oterm.py
@@ -12,7 +12,16 @@ cli = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
 
 
 async def upgrade_db():
-    await Store.get_store()
+    from oterm.tools import load_tools
+    from oterm.tools.mcp.setup import teardown_mcp_servers
+
+    # The 0.22.0 upgrade qualifies MCP tool names by server, which it can only
+    # do while the servers are connected.
+    await load_tools()
+    try:
+        await Store.get_store()
+    finally:
+        await teardown_mcp_servers()
 
 
 @cli.command()

--- a/src/oterm/store/upgrades/__init__.py
+++ b/src/oterm/store/upgrades/__init__.py
@@ -1,4 +1,5 @@
 from oterm.store.upgrades.v0_15_0 import upgrades as v0_15_0_upgrades
 from oterm.store.upgrades.v0_18_0 import upgrades as v0_18_0_upgrades
+from oterm.store.upgrades.v0_22_0 import upgrades as v0_22_0_upgrades
 
-upgrades = v0_15_0_upgrades + v0_18_0_upgrades
+upgrades = v0_15_0_upgrades + v0_18_0_upgrades + v0_22_0_upgrades

--- a/src/oterm/store/upgrades/v0_22_0.py
+++ b/src/oterm/store/upgrades/v0_22_0.py
@@ -1,0 +1,51 @@
+import json
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import aiosqlite
+
+
+async def qualify_mcp_tool_names(db_path: Path) -> None:
+    """Rewrite MCP tool selections as `{server}_{tool}`.
+
+    Reads the tool-to-server map from the connected MCP servers, so it must run
+    after `load_tools()`. A bare name exported by several servers expands to one
+    entry per server; names no connected server exports are left as they are.
+    """
+    from oterm.tools import builtin_tools, qualified_tool_name
+    from oterm.tools.capabilities import capability_defs
+    from oterm.tools.mcp.setup import mcp_tool_meta
+
+    local_names = {t["name"] for t in builtin_tools} | {
+        c["name"] for c in capability_defs
+    }
+    owners: dict[str, list[str]] = {}
+    for server, metas in mcp_tool_meta.items():
+        for meta in metas:
+            if meta["name"] not in local_names:
+                owners.setdefault(meta["name"], []).append(server)
+    if not owners:
+        return
+
+    async with aiosqlite.connect(db_path) as connection:
+        rows = await connection.execute_fetchall("SELECT id, tools FROM chat")
+        for chat_id, tools_json in list(rows):
+            names = json.loads(tools_json or "[]")
+            qualified: list[str] = []
+            for name in names:
+                servers = owners.get(name)
+                if servers:
+                    qualified.extend(qualified_tool_name(s, name) for s in servers)
+                else:
+                    qualified.append(name)
+            if qualified != names:
+                await connection.execute(
+                    "UPDATE chat SET tools = ? WHERE id = ?",
+                    (json.dumps(qualified), chat_id),
+                )
+        await connection.commit()
+
+
+upgrades: list[tuple[str, list[Callable[[Path], Awaitable[None]]]]] = [
+    ("0.22.0", [qualify_mcp_tool_names]),
+]

--- a/src/oterm/tools/__init__.py
+++ b/src/oterm/tools/__init__.py
@@ -9,6 +9,11 @@ from oterm.types import ToolDef
 builtin_tools: list[ToolDef] = []
 
 
+def qualified_tool_name(server: str, tool: str) -> str:
+    """Identity of an MCP tool, matching the name `PrefixedToolset` exposes."""
+    return f"{server}_{tool}"
+
+
 def known_tool_names() -> set[str]:
     """Names of everything currently selectable (builtin + capabilities + connected MCP)."""
     from oterm.tools.capabilities import capability_defs
@@ -16,8 +21,8 @@ def known_tool_names() -> set[str]:
 
     names = {t["name"] for t in builtin_tools}
     names.update(c["name"] for c in capability_defs)
-    for metas in mcp_tool_meta.values():
-        names.update(m["name"] for m in metas)
+    for server, metas in mcp_tool_meta.items():
+        names.update(qualified_tool_name(server, m["name"]) for m in metas)
     return names
 
 
@@ -28,6 +33,15 @@ def make_tool_def(func: Callable) -> ToolDef:
         "description": pydantic_tool.description or "",
         "tool": pydantic_tool,
     }
+
+
+async def load_tools() -> None:
+    """Populate `builtin_tools` and connect the configured MCP servers."""
+    from oterm.tools.mcp.setup import setup_mcp_servers
+
+    builtin_tools.clear()
+    builtin_tools.extend(discover_tools())
+    await setup_mcp_servers()
 
 
 def discover_tools() -> list[ToolDef]:

--- a/src/oterm/tools/mcp/setup.py
+++ b/src/oterm/tools/mcp/setup.py
@@ -1,10 +1,12 @@
 import contextlib
+import re
 
 from fastmcp.client.transports import StdioTransport
 from pydantic_ai.mcp import MCPToolset
 
 from oterm.config import appConfig
 from oterm.log import log
+from oterm.tools import qualified_tool_name
 from oterm.tools.mcp.logging import log_handler
 from oterm.utils import expand_env_vars
 
@@ -15,6 +17,12 @@ _STDIO_LOG_ENV = {
     "RUST_LOG": "error",
     "FASTMCP_LOG_LEVEL": "ERROR",
 }
+
+# Providers accept tool names matching ^[a-zA-Z0-9_-]{1,64}$. A server's name
+# prefixes each of its tool names, so the charset applies to the name itself
+# and the length limit to the combination.
+_SERVER_NAME = re.compile(r"[a-zA-Z0-9_-]+")
+_TOOL_NAME_MAX_LENGTH = 64
 
 
 class ToolMeta(dict):
@@ -33,6 +41,12 @@ def _build_toolset(name: str, entry: dict) -> MCPToolset:
     (`command` / `args` / `env` / `cwd`). Rejects WebSocket URLs explicitly
     so users get a clear error instead of a transport-layer failure.
     """
+    if not _SERVER_NAME.fullmatch(name):
+        raise ValueError(
+            f"MCP server {name!r}: the name may only contain letters, digits, "
+            "underscores and hyphens, as it prefixes every tool name sent to "
+            "the model."
+        )
     url = entry.get("url")
     if isinstance(url, str):
         if url.startswith(("ws://", "wss://")):
@@ -96,11 +110,21 @@ async def setup_mcp_servers() -> dict[str, list[ToolMeta]]:
         except Exception as e:
             log.error(f"MCP server {name!r} failed to initialize: {e}")
             continue
+        metas: list[ToolMeta] = []
+        for tool in tools:
+            qualified = qualified_tool_name(name, tool.name)
+            if len(qualified) > _TOOL_NAME_MAX_LENGTH:
+                log.error(
+                    f"MCP server {name!r}: skipping tool {tool.name!r}, as "
+                    f"{qualified!r} is over the {_TOOL_NAME_MAX_LENGTH} character "
+                    "limit providers impose. Use a shorter server name."
+                )
+                continue
+            metas.append(ToolMeta(name=tool.name, description=tool.description or ""))
+
         mcp_servers[name] = toolset
-        mcp_tool_meta[name] = [
-            ToolMeta(name=t.name, description=t.description or "") for t in tools
-        ]
-        log.info(f"Loaded MCP server {name} with {len(tools)} tool(s)")
+        mcp_tool_meta[name] = metas
+        log.info(f"Loaded MCP server {name} with {len(metas)} tool(s)")
 
     return mcp_tool_meta
 

--- a/tests/agent/test_errors.py
+++ b/tests/agent/test_errors.py
@@ -1,8 +1,20 @@
+from types import SimpleNamespace
+
 import pytest
 from pydantic_ai import Tool as PydanticTool
+from pydantic_ai.messages import ToolReturnPart
 
 from oterm.app.widgets.chat import ChatContainer, _resolve_tools
 from oterm.types import ChatModel
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.filtered_args: list = []
+
+    def filtered(self, predicate):
+        self.filtered_args.append(predicate)
+        return f"toolset-{id(predicate)}"
 
 
 class TestResolveTools:
@@ -56,14 +68,8 @@ class TestResolveTools:
         messages = [msg for _, msg in oterm.log.log_lines[before:]]
         assert not any("unavailable tools" in m for m in messages)
 
-    def test_mcp_tools_become_filtered_toolset(self, monkeypatch):
-        class _FakeServer:
-            def __init__(self) -> None:
-                self.filtered_args: list = []
-
-            def filtered(self, predicate):
-                self.filtered_args.append(predicate)
-                return f"toolset-{id(predicate)}"
+    def test_mcp_tools_become_prefixed_filtered_toolset(self, monkeypatch):
+        from pydantic_ai.toolsets import PrefixedToolset
 
         server = _FakeServer()
         monkeypatch.setattr("oterm.app.widgets.chat.builtin_tools", [])
@@ -72,16 +78,129 @@ class TestResolveTools:
             {"oracle": [{"name": "ask_oracle", "description": ""}]},
         )
         monkeypatch.setattr("oterm.app.widgets.chat.mcp_servers", {"oracle": server})
-        tools, toolsets, capabilities = _resolve_tools(["ask_oracle"])
+        tools, toolsets, capabilities = _resolve_tools(["oracle_ask_oracle"])
         assert tools == []
         assert capabilities == []
         assert len(toolsets) == 1
-        # The filter predicate accepts the chosen tool name and rejects others.
-        from types import SimpleNamespace
-
+        assert isinstance(toolsets[0], PrefixedToolset)
+        assert toolsets[0].prefix == "oracle"
+        # The filter predicate sees unprefixed names, as it wraps the raw toolset.
         predicate = server.filtered_args[0]
         assert predicate(None, SimpleNamespace(name="ask_oracle")) is True
         assert predicate(None, SimpleNamespace(name="other")) is False
+
+    def test_same_tool_name_on_two_servers_resolves_both_independently(
+        self, monkeypatch
+    ):
+        """Regression for #321: a name shared by two servers must not conflict."""
+        k8s, grafana = _FakeServer(), _FakeServer()
+        monkeypatch.setattr("oterm.app.widgets.chat.builtin_tools", [])
+        monkeypatch.setattr(
+            "oterm.app.widgets.chat.mcp_tool_meta",
+            {
+                "k8s": [{"name": "query_prometheus", "description": ""}],
+                "grafana": [{"name": "query_prometheus", "description": ""}],
+            },
+        )
+        monkeypatch.setattr(
+            "oterm.app.widgets.chat.mcp_servers", {"k8s": k8s, "grafana": grafana}
+        )
+        _, toolsets, _ = _resolve_tools(["k8s_query_prometheus"])
+        assert [ts.prefix for ts in toolsets] == ["k8s"]
+        assert grafana.filtered_args == []
+
+        _, toolsets, _ = _resolve_tools(
+            ["k8s_query_prometheus", "grafana_query_prometheus"]
+        )
+        assert sorted(ts.prefix for ts in toolsets) == ["grafana", "k8s"]
+
+    def test_unqualified_mcp_tool_name_is_unavailable(self, monkeypatch):
+        """A bare MCP tool name no longer resolves to any server."""
+        import oterm.log
+
+        server = _FakeServer()
+        monkeypatch.setattr("oterm.app.widgets.chat.builtin_tools", [])
+        monkeypatch.setattr(
+            "oterm.app.widgets.chat.mcp_tool_meta",
+            {"oracle": [{"name": "ask_oracle", "description": ""}]},
+        )
+        monkeypatch.setattr("oterm.app.widgets.chat.mcp_servers", {"oracle": server})
+        before = len(oterm.log.log_lines)
+        _, toolsets, _ = _resolve_tools(["ask_oracle"])
+        assert toolsets == []
+        messages = [msg for _, msg in oterm.log.log_lines[before:]]
+        assert any("unavailable tools" in m and "ask_oracle" in m for m in messages)
+
+
+class TestMcpToolNameCollisions:
+    """Regression for #321, driving real toolsets through a real agent."""
+
+    @staticmethod
+    def _two_servers(monkeypatch):
+        from pydantic_ai.toolsets import FunctionToolset
+
+        def k8s_query_prometheus() -> str:
+            return "k8s"
+
+        def grafana_query_prometheus() -> str:
+            return "grafana"
+
+        k8s = FunctionToolset(id="k8s")
+        k8s.add_function(k8s_query_prometheus, name="query_prometheus")
+        grafana = FunctionToolset(id="grafana")
+        grafana.add_function(grafana_query_prometheus, name="query_prometheus")
+
+        monkeypatch.setattr("oterm.app.widgets.chat.builtin_tools", [])
+        monkeypatch.setattr(
+            "oterm.app.widgets.chat.mcp_tool_meta",
+            {
+                "k8s": [{"name": "query_prometheus", "description": ""}],
+                "grafana": [{"name": "query_prometheus", "description": ""}],
+            },
+        )
+        monkeypatch.setattr(
+            "oterm.app.widgets.chat.mcp_servers", {"k8s": k8s, "grafana": grafana}
+        )
+
+    async def test_both_servers_expose_the_shared_name_without_conflict(
+        self, monkeypatch
+    ):
+        from pydantic_ai.models.test import TestModel
+
+        from oterm.agent import get_agent
+
+        self._two_servers(monkeypatch)
+        _, toolsets, _ = _resolve_tools(
+            ["k8s_query_prometheus", "grafana_query_prometheus"]
+        )
+        agent = get_agent(model="llama3", toolsets=toolsets)
+        result = await agent.run("go", model=TestModel())
+
+        called = {
+            part.tool_name
+            for message in result.all_messages()
+            for part in message.parts
+            if hasattr(part, "tool_name")
+        }
+        assert {"k8s_query_prometheus", "grafana_query_prometheus"} <= called
+
+    async def test_selecting_one_server_calls_only_that_server(self, monkeypatch):
+        from pydantic_ai.models.test import TestModel
+
+        from oterm.agent import get_agent
+
+        self._two_servers(monkeypatch)
+        _, toolsets, _ = _resolve_tools(["grafana_query_prometheus"])
+        agent = get_agent(model="llama3", toolsets=toolsets)
+        result = await agent.run("go", model=TestModel())
+
+        returns = [
+            (part.tool_name, part.content)
+            for message in result.all_messages()
+            for part in message.parts
+            if isinstance(part, ToolReturnPart)
+        ]
+        assert returns == [("grafana_query_prometheus", "grafana")]
 
 
 class TestRebuildAgent:

--- a/tests/app/test_oterm_app.py
+++ b/tests/app/test_oterm_app.py
@@ -8,6 +8,7 @@ from oterm.types import ChatModel, MessageModel
 def stub_network(monkeypatch):
     """Keep OTerm.on_mount from touching the network or spawning MCP servers."""
     import oterm.app.oterm as oterm_mod
+    import oterm.tools.mcp.setup as mcp_setup_mod
     import oterm.utils as utils_mod
 
     async def _up_to_date():
@@ -23,7 +24,7 @@ def stub_network(monkeypatch):
 
     monkeypatch.setattr(utils_mod, "is_up_to_date", _up_to_date)
     monkeypatch.setattr(oterm_mod, "is_up_to_date", _up_to_date)
-    monkeypatch.setattr(oterm_mod, "setup_mcp_servers", _no_mcp)
+    monkeypatch.setattr(mcp_setup_mod, "setup_mcp_servers", _no_mcp)
 
     async def _no_teardown():
         return None
@@ -232,8 +233,8 @@ class TestLoadTools:
     async def test_discovers_entry_point_tools(
         self, tmp_data_dir, app_config, stub_network
     ):
-        import oterm.app.oterm as oterm_mod
         import oterm.tools as tools_mod
+        import oterm.tools.mcp.setup as mcp_setup_mod
 
         def fake_tool() -> str:
             """Sample."""
@@ -253,7 +254,7 @@ class TestLoadTools:
         original_discover = tools_mod.discover_tools
         original_builtins = tools_mod.builtin_tools
         tools_mod.discover_tools = fake_discover  # ty: ignore[invalid-assignment]
-        oterm_mod.setup_mcp_servers = fake_mcp_setup  # ty: ignore[invalid-assignment]
+        mcp_setup_mod.setup_mcp_servers = fake_mcp_setup  # ty: ignore[invalid-assignment]
         try:
             from oterm.app.oterm import OTerm
 

--- a/tests/tools/test_discovery.py
+++ b/tests/tools/test_discovery.py
@@ -1,6 +1,11 @@
 from pydantic_ai import Tool as PydanticTool
 
-from oterm.tools import builtin_tools, discover_tools, make_tool_def
+from oterm.tools import (
+    builtin_tools,
+    discover_tools,
+    known_tool_names,
+    make_tool_def,
+)
 
 
 def _hello() -> str:
@@ -74,3 +79,26 @@ class TestDiscoverTools:
 
 def test_builtin_tools_is_a_list():
     assert isinstance(builtin_tools, list)
+
+
+class TestKnownToolNames:
+    def test_mcp_names_are_qualified_by_server(self, monkeypatch):
+        import oterm.tools as tools_mod
+        import oterm.tools.capabilities as capabilities_mod
+        import oterm.tools.mcp.setup as mcp_setup_mod
+
+        monkeypatch.setattr(tools_mod, "builtin_tools", [{"name": "shell"}])
+        monkeypatch.setattr(capabilities_mod, "capability_defs", [])
+        monkeypatch.setattr(
+            mcp_setup_mod,
+            "mcp_tool_meta",
+            {
+                "k8s": [{"name": "query_prometheus", "description": ""}],
+                "grafana": [{"name": "query_prometheus", "description": ""}],
+            },
+        )
+        assert known_tool_names() == {
+            "shell",
+            "k8s_query_prometheus",
+            "grafana_query_prometheus",
+        }

--- a/tests/tools/test_mcp_setup.py
+++ b/tests/tools/test_mcp_setup.py
@@ -84,6 +84,17 @@ class TestBuildToolsets:
         with pytest.raises(ValueError, match="WebSocket transport"):
             _build_toolsets({"wss": {"url": "wss://example.com/mcp"}})
 
+    @pytest.mark.parametrize("name", ["k8s.lab", "my server", "a/b", "grafana!"])
+    def test_server_name_with_provider_invalid_characters_rejected(self, name):
+        """The name prefixes every tool sent to the model, so providers see it."""
+        with pytest.raises(ValueError, match="letters, digits"):
+            _build_toolsets({name: {"url": "http://example.com/mcp"}})
+
+    @pytest.mark.parametrize("name", ["k8s", "my-server", "my_server", "grafana2"])
+    def test_provider_valid_server_names_accepted(self, name):
+        built = _build_toolsets({name: {"url": "http://example.com/mcp"}})
+        assert name in built
+
     def test_env_var_substitution_in_env_values(self, monkeypatch):
         monkeypatch.setenv("MY_TOKEN", "shh")
         built = _build_toolsets(
@@ -197,6 +208,46 @@ class TestSetupAndTeardown:
             assert meta == {}
             messages = [msg for _, msg in oterm.log.log_lines[before:]]
             assert any("WebSocket" in m for m in messages)
+        finally:
+            await teardown_mcp_servers()
+
+    async def test_invalid_server_name_in_config_logs_and_skips_all(self, app_config):
+        import oterm.log
+
+        app_config.set("mcpServers", {"k8s.lab": {"url": "http://localhost/mcp"}})
+        before = len(oterm.log.log_lines)
+        try:
+            meta = await setup_mcp_servers()
+            assert meta == {}
+            messages = [msg for _, msg in oterm.log.log_lines[before:]]
+            assert any("k8s.lab" in m and "letters, digits" in m for m in messages)
+        finally:
+            await teardown_mcp_servers()
+
+    async def test_tool_over_provider_name_limit_is_dropped(
+        self, app_config, mcp_server_config
+    ):
+        """`{server}_{tool}` must stay within the 64 characters providers allow."""
+        import oterm.log
+
+        long_name = "s" * 60
+        app_config.set("mcpServers", {long_name: mcp_server_config["stdio"]})
+        before = len(oterm.log.log_lines)
+        try:
+            meta = await setup_mcp_servers()
+            assert meta[long_name] == []
+            messages = [msg for _, msg in oterm.log.log_lines[before:]]
+            assert any("oracle" in m and "64" in m for m in messages)
+        finally:
+            await teardown_mcp_servers()
+
+    async def test_tools_within_provider_name_limit_are_kept(
+        self, app_config, mcp_server_config
+    ):
+        app_config.set("mcpServers", {"short": mcp_server_config["stdio"]})
+        try:
+            meta = await setup_mcp_servers()
+            assert {m["name"] for m in meta["short"]} == {"oracle", "puzzle_solver"}
         finally:
             await teardown_mcp_servers()
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,62 @@
+import pytest
+
+from oterm.cli.oterm import upgrade_db
+
+
+class TestUpgradeDb:
+    async def test_tools_load_before_store_and_tear_down_after(
+        self, tmp_data_dir, monkeypatch
+    ):
+        """The 0.22.0 upgrade reads the connected servers, so ordering matters."""
+        import oterm.cli.oterm as cli_mod
+        import oterm.tools as tools_mod
+        import oterm.tools.mcp.setup as mcp_setup_mod
+
+        calls: list[str] = []
+
+        async def fake_load_tools():
+            calls.append("load_tools")
+
+        async def fake_teardown():
+            calls.append("teardown")
+
+        class _FakeStore:
+            @classmethod
+            async def get_store(cls):
+                calls.append("get_store")
+
+        monkeypatch.setattr(tools_mod, "load_tools", fake_load_tools)
+        monkeypatch.setattr(mcp_setup_mod, "teardown_mcp_servers", fake_teardown)
+        monkeypatch.setattr(cli_mod, "Store", _FakeStore)
+
+        await upgrade_db()
+
+        assert calls == ["load_tools", "get_store", "teardown"]
+
+    async def test_servers_torn_down_when_upgrade_fails(
+        self, tmp_data_dir, monkeypatch
+    ):
+        import oterm.cli.oterm as cli_mod
+        import oterm.tools as tools_mod
+        import oterm.tools.mcp.setup as mcp_setup_mod
+
+        torn_down: list[bool] = []
+
+        async def fake_load_tools():
+            return None
+
+        async def fake_teardown():
+            torn_down.append(True)
+
+        class _BrokenStore:
+            @classmethod
+            async def get_store(cls):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(tools_mod, "load_tools", fake_load_tools)
+        monkeypatch.setattr(mcp_setup_mod, "teardown_mcp_servers", fake_teardown)
+        monkeypatch.setattr(cli_mod, "Store", _BrokenStore)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await upgrade_db()
+        assert torn_down == [True]

--- a/tests/unit/test_store_upgrades.py
+++ b/tests/unit/test_store_upgrades.py
@@ -8,6 +8,7 @@ from oterm.store.upgrades.v0_15_0 import (
     migrate_tools_to_names,
 )
 from oterm.store.upgrades.v0_18_0 import rename_providers
+from oterm.store.upgrades.v0_22_0 import qualify_mcp_tool_names
 
 
 async def _old_chat_schema(db_path):
@@ -209,6 +210,121 @@ class TestMigrateToolsToNames:
         async with aiosqlite.connect(db) as c:
             rows = await c.execute_fetchall("SELECT tools FROM chat")
             assert list(rows)[0][0] == "[]"
+
+
+class TestQualifyMcpToolNames:
+    @staticmethod
+    def _servers(monkeypatch, meta, builtin=(), capabilities=()):
+        import oterm.tools as tools_mod
+        import oterm.tools.capabilities as capabilities_mod
+        import oterm.tools.mcp.setup as mcp_setup_mod
+
+        monkeypatch.setattr(tools_mod, "builtin_tools", [{"name": n} for n in builtin])
+        monkeypatch.setattr(
+            capabilities_mod, "capability_defs", [{"name": n} for n in capabilities]
+        )
+        monkeypatch.setattr(mcp_setup_mod, "mcp_tool_meta", meta)
+
+    async def _chat_tools(self, db, tools):
+        await _old_chat_schema(db)
+        async with aiosqlite.connect(db) as c:
+            await c.execute(
+                "INSERT INTO chat(name, model, tools) VALUES(?, ?, ?)",
+                ("c", "m", json.dumps(tools)),
+            )
+            await c.commit()
+
+    @staticmethod
+    async def _read_tools(db):
+        async with aiosqlite.connect(db) as c:
+            rows = await c.execute_fetchall("SELECT tools FROM chat")
+            return json.loads(list(rows)[0][0])
+
+    async def test_prefixes_bare_mcp_names_with_owning_server(
+        self, tmp_path, monkeypatch
+    ):
+        db = tmp_path / "store.db"
+        await self._chat_tools(db, ["shell", "list_pods"])
+        self._servers(
+            monkeypatch,
+            {"k8s": [{"name": "list_pods", "description": ""}]},
+            builtin=["shell"],
+        )
+
+        await qualify_mcp_tool_names(db)
+
+        assert await self._read_tools(db) == ["shell", "k8s_list_pods"]
+
+    async def test_ambiguous_name_expands_to_every_owning_server(
+        self, tmp_path, monkeypatch
+    ):
+        """Pre-0.22 a bare name pulled in every server exporting it; keep that intent."""
+        db = tmp_path / "store.db"
+        await self._chat_tools(db, ["query_prometheus"])
+        self._servers(
+            monkeypatch,
+            {
+                "k8s": [{"name": "query_prometheus", "description": ""}],
+                "grafana": [{"name": "query_prometheus", "description": ""}],
+            },
+        )
+
+        await qualify_mcp_tool_names(db)
+
+        assert await self._read_tools(db) == [
+            "k8s_query_prometheus",
+            "grafana_query_prometheus",
+        ]
+
+    async def test_builtin_and_capability_names_win_over_mcp(
+        self, tmp_path, monkeypatch
+    ):
+        """An MCP server exporting `shell` must not steal the builtin selection."""
+        db = tmp_path / "store.db"
+        await self._chat_tools(db, ["shell", "memory"])
+        self._servers(
+            monkeypatch,
+            {
+                "sandbox": [
+                    {"name": "shell", "description": ""},
+                    {"name": "memory", "description": ""},
+                ]
+            },
+            builtin=["shell"],
+            capabilities=["memory"],
+        )
+
+        await qualify_mcp_tool_names(db)
+
+        assert await self._read_tools(db) == ["shell", "memory"]
+
+    async def test_unknown_names_are_left_untouched(self, tmp_path, monkeypatch):
+        """A name no connected server exports is preserved rather than dropped."""
+        db = tmp_path / "store.db"
+        await self._chat_tools(db, ["ghost"])
+        self._servers(monkeypatch, {"k8s": [{"name": "list_pods", "description": ""}]})
+
+        await qualify_mcp_tool_names(db)
+
+        assert await self._read_tools(db) == ["ghost"]
+
+    async def test_no_connected_servers_is_noop(self, tmp_path, monkeypatch):
+        db = tmp_path / "store.db"
+        await self._chat_tools(db, ["list_pods"])
+        self._servers(monkeypatch, {})
+
+        await qualify_mcp_tool_names(db)
+
+        assert await self._read_tools(db) == ["list_pods"]
+
+    async def test_already_qualified_names_pass_through(self, tmp_path, monkeypatch):
+        db = tmp_path / "store.db"
+        await self._chat_tools(db, ["k8s_list_pods"])
+        self._servers(monkeypatch, {"k8s": [{"name": "list_pods", "description": ""}]})
+
+        await qualify_mcp_tool_names(db)
+
+        assert await self._read_tools(db) == ["k8s_list_pods"]
 
 
 class TestRenameProviders:

--- a/tests/widgets/test_tool_select.py
+++ b/tests/widgets/test_tool_select.py
@@ -32,6 +32,7 @@ def populated_tools(monkeypatch):
     ]
     mcp_meta = {
         "mcp_server": [{"name": "oracle", "description": "oracle tool"}],
+        "other_server": [{"name": "oracle", "description": "another oracle tool"}],
     }
 
     monkeypatch.setattr(tools_mod, "builtin_tools", builtin)
@@ -63,10 +64,12 @@ class TestToolSelector:
                 "builtin",
                 "capabilities",
                 "mcp_server",
+                "other_server",
                 "date_time",
                 "shell",
                 "web_search",
-                "oracle",
+                "mcp_server_oracle",
+                "other_server_oracle",
             }.issubset(names)
 
     async def test_initial_selection_reflected_in_checkboxes(self, populated_tools):
@@ -140,10 +143,41 @@ class TestToolSelector:
             selector = app.query_one(ToolSelector)
             await pilot.pause()
 
-            oracle_cb = selector.query_one("#mcp_server-oracle", Checkbox)
+            oracle_cb = selector.query_one("#mcp_server-mcp_server_oracle", Checkbox)
             oracle_cb.value = True
             await pilot.pause()
-            assert "oracle" in selector.selected
+            assert "mcp_server_oracle" in selector.selected
+
+    async def test_same_tool_name_on_two_servers_selected_independently(
+        self, populated_tools
+    ):
+        """Regression for #321: selecting one server's tool leaves the other alone."""
+        app = _Host(selected=["mcp_server_oracle"])
+        async with app.run_test() as pilot:
+            selector = app.query_one(ToolSelector)
+            await pilot.pause()
+            assert (
+                selector.query_one("#mcp_server-mcp_server_oracle", Checkbox).value
+                is True
+            )
+            assert (
+                selector.query_one("#other_server-other_server_oracle", Checkbox).value
+                is False
+            )
+
+    async def test_group_select_all_reflects_only_its_own_server(self, populated_tools):
+        """A server's select-all box ignores identically named tools on other servers."""
+        app = _Host(selected=["mcp_server_oracle"])
+        async with app.run_test() as pilot:
+            selector = app.query_one(ToolSelector)
+            await pilot.pause()
+            groups = {
+                c.name: c
+                for c in selector.query(Checkbox)
+                if c.has_class("tool-group-select-all")
+            }
+            assert groups["mcp_server"].value is True
+            assert groups["other_server"].value is False
 
     async def test_unknown_checkbox_name_is_ignored(self, populated_tools):
         """Defensive: a Checkbox.Changed with a name we don't recognize is a no-op."""


### PR DESCRIPTION
Tool identity was the bare tool name, so a name exported by two MCP servers resolved to both toolsets and pydantic-ai rejected the agent. MCP tools are now identified as `{server}_{tool}` and reach the model through `PrefixedToolset`, so each server's tools are selectable independently.

Since the server name now reaches the provider, names outside `[a-zA-Z0-9_-]` are refused when the config loads, and tools whose qualified name exceeds 64 characters are skipped.

The `0.22.0` store upgrade rewrites existing chat selections, so tools load before the store to give it the connected servers' tool lists.

Closes #321
