### PR TITLE
Add a keybinding for copying the last message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - New chats pre-select the provider of the last created chat. ([#298](https://github.com/ggozad/oterm/issues/298))
+- Copy the last message of the current chat, bound to <kbd>Ctrl</kbd>+<kbd>o</kbd> (`copy.message`), with a matching `Copy message` command palette entry. ([#310](https://github.com/ggozad/oterm/issues/310))
 
 ## [0.22.0] - 2026-07-31
 

--- a/docs/app_config.md
+++ b/docs/app_config.md
@@ -27,6 +27,7 @@ A complete example showing every supported key:
     "prev.chat": "ctrl+shift+tab",
     "new.chat": "ctrl+n",
     "toggle.thinking": "ctrl+t",
+    "copy.message": "ctrl+o",
     "show.logs": "ctrl+l",
     "quit": "ctrl+q",
     "newline": "shift+enter",
@@ -59,7 +60,11 @@ Each key is optional; the sections below cover them in turn. For `mcpServers`, s
 
 ### `keymap` — customizing key bindings
 
-Sane defaults are provided, but terminal emulators and shells will sometimes intercept them. Override any of the bindings below by setting the matching key in the `keymap` block:
+Sane defaults are provided, but terminal emulators and shells will sometimes intercept them.
+
+When picking a replacement, avoid the keys the prompt's text editor already claims. The prompt is focused most of the time, and a binding on the focused widget wins over an application one, so such a key will silently do nothing. The editor takes most navigation and editing keys, notably `ctrl+a`, `ctrl+c`, `ctrl+d`, `ctrl+e`, `ctrl+k`, `ctrl+u`, `ctrl+v`, `ctrl+w`, `ctrl+x`, `ctrl+y`, `ctrl+z`, `ctrl+shift+k`, `ctrl+backspace`, `ctrl+left` and `ctrl+right` (with their `shift` variants), `f6`, `f7`, the arrow keys, `home`, `end`, `pageup`, `pagedown`, and the `super+` equivalents on macOS. The authoritative list is `TextArea.BINDINGS` in the installed version of Textual.
+
+Override any of the bindings below by setting the matching key in the `keymap` block:
 
 | ID          | Default            | Action                                                                  |
 | ----------- | ------------------ | ----------------------------------------------------------------------- |
@@ -67,6 +72,7 @@ Sane defaults are provided, but terminal emulators and shells will sometimes int
 | `prev.chat` | `ctrl+shift+tab`   | Switch to the previous chat tab.                                        |
 | `new.chat`  | `ctrl+n`           | Open the new-chat dialog.                                               |
 | `toggle.thinking` | `ctrl+t`     | Turn thinking mode on or off for the current session (not persisted).  |
+| `copy.message` | `ctrl+o`        | Copy the last message of the current chat to the clipboard.             |
 | `show.logs` | `ctrl+l`           | Open the log viewer.                                                    |
 | `quit`      | `ctrl+q`           | Quit `oterm`.                                                           |
 | `newline`   | `shift+enter`      | Insert a newline in the prompt. `ctrl+m` is also accepted as a fallback for terminals that can't distinguish `shift+enter` from `enter`, and is not configurable. |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,6 +24,7 @@ The following keyboard shortcuts are supported:
 * <kbd>Shift</kbd>+<kbd>Enter</kbd> or <kbd>^ Ctrl</kbd>+<kbd>m</kbd> - insert a newline; the prompt grows to fit (up to 10 lines)
 * <kbd>^ Ctrl</kbd>+<kbd>i</kbd> - select an image to include with the next message
 * <kbd>↑/↓</kbd> (while messages are focused) - navigate through the messages
+* <kbd>^ Ctrl</kbd>+<kbd>o</kbd> - copy the last message of the current chat to the clipboard
 * <kbd>^ Ctrl</kbd>+<kbd>l</kbd> - show logs
 
 * <kbd>^ Ctrl</kbd>+<kbd>n</kbd> - open a new chat
@@ -43,6 +44,7 @@ While the model is inferring the next message, you can press <kbd>Esc</kbd> to c
 
 It is difficult to properly support copy/paste in terminal applications. You can copy blocks to your clipboard as such:
 
+* <kbd>^ Ctrl</kbd>+<kbd>o</kbd> will copy the last message of the current chat to the clipboard.
 * clicking a message will copy it to the clipboard.
 * clicking a code block will only copy the code block to the clipboard.
 

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -38,6 +38,7 @@ class OTerm(App):
         ),
         Binding("ctrl+n", "new_chat", "new chat", id="new.chat"),
         Binding("ctrl+t", "toggle_thinking", "toggle thinking", id="toggle.thinking"),
+        Binding("ctrl+o", "copy_message", "copy message", id="copy.message"),
         Binding("ctrl+l", "show_logs", "show logs", id="show.logs"),
         Binding("ctrl+q", "quit", "quit", id="quit"),
     ]
@@ -54,6 +55,11 @@ class OTerm(App):
             "Toggle thinking",
             "Turns thinking mode on or off for the current chat",
             self.action_toggle_thinking,
+        )
+        yield SystemCommand(
+            "Copy message",
+            "Copies the last message of the current chat to the clipboard",
+            self.action_copy_message,
         )
         yield SystemCommand(
             "Rename chat", "Renames the current chat", self.action_rename_chat
@@ -145,6 +151,13 @@ class OTerm(App):
             return
         chat = tabs.active_pane.query_one(ChatContainer)
         chat.action_toggle_thinking()
+
+    async def action_copy_message(self) -> None:
+        tabs = self.query_one(TabbedContent)
+        if tabs.active_pane is None:
+            return
+        chat = tabs.active_pane.query_one(ChatContainer)
+        chat.action_copy_message()
 
     async def action_rename_chat(self) -> None:
         tabs = self.query_one(TabbedContent)

--- a/src/oterm/app/widgets/chat.py
+++ b/src/oterm/app/widgets/chat.py
@@ -558,6 +558,13 @@ class ChatContainer(Widget):
         self._rebuild_agent()
         self.app.notify(f"Thinking {'on' if self.chat_model.thinking else 'off'}.")
 
+    def action_copy_message(self) -> None:
+        """Copy the last message. Reads the widget, not ``self.messages``, which
+        is only appended once a response has finished streaming."""
+        items = list(self.query_one("#messageContainer").query(ChatItem))
+        if items:
+            items[-1].copy()
+
     @work
     async def action_rename_chat(self) -> None:
         chat_id = self.chat_model.id
@@ -843,6 +850,11 @@ class ChatItem(Widget):
                 return
             cur = cur.parent  # ty: ignore[invalid-assignment]
 
+        self.copy()
+
+    def copy(self) -> None:
+        if not self.text:
+            return
         self.app.copy_to_clipboard(self.text)
         widgets = self.query(".text")
         for widget in widgets:

--- a/tests/app/test_oterm_app.py
+++ b/tests/app/test_oterm_app.py
@@ -463,6 +463,30 @@ class TestActionDelegates:
             await pilot.pause()
             assert called == [True]
 
+    async def test_copy_message_delegates(
+        self, tmp_data_dir, app_config, stub_network, store, monkeypatch
+    ):
+        from oterm.app.oterm import OTerm
+        from oterm.app.widgets.chat import ChatContainer
+
+        app_config.set("splash-screen", False)
+        cm = ChatModel(name="c", model="m")
+        cm.id = await store.save_chat(cm)
+
+        app = OTerm()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            called: list[bool] = []
+
+            def spy(self):
+                called.append(True)
+
+            monkeypatch.setattr(ChatContainer, "action_copy_message", spy)
+            await app.action_copy_message()
+            await pilot.pause()
+            assert called == [True]
+
     async def test_regenerate_last_message_delegates(
         self, tmp_data_dir, app_config, stub_network, store, monkeypatch
     ):
@@ -506,6 +530,7 @@ class TestActionDelegates:
             await app.action_regenerate_last_message()
             await app.action_clear_chat()
             await app.action_prompt_history()
+            await app.action_copy_message()
 
     async def test_prompt_history_delegates_to_active_container(
         self, tmp_data_dir, app_config, stub_network, store, monkeypatch
@@ -731,6 +756,42 @@ class TestKeymap:
             await pilot.pause()
             assert calls == [True]
 
+    async def test_copy_message_key_reaches_the_action_from_the_prompt(
+        self, tmp_data_dir, app_config, stub_network, store, monkeypatch
+    ):
+        """The prompt is focused on mount, so the default must not be a key
+        PostableTextArea already claims (it inherits all of TextArea.BINDINGS)."""
+        import oterm.app.oterm as oterm_mod
+        from oterm.app.widgets.prompt import PostableTextArea
+
+        app_config.set("splash-screen", False)
+        cm = ChatModel(name="c", model="m")
+        cm.id = await store.save_chat(cm)
+
+        calls: list[bool] = []
+
+        async def spy(self):
+            calls.append(True)
+
+        monkeypatch.setattr(oterm_mod.OTerm, "action_copy_message", spy)
+
+        app = oterm_mod.OTerm()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tabs = app.query_one(TabbedContent)
+            assert tabs.active_pane is not None
+            prompt = tabs.active_pane.query_one(PostableTextArea)
+            prompt.focus()
+            await pilot.pause()
+            assert app.focused is prompt
+
+            key = next(
+                b.key for b in oterm_mod.OTerm.BINDINGS if b.id == "copy.message"
+            )
+            await pilot.press(key)
+            await pilot.pause()
+            assert calls == [True]
+
     async def test_keymap_remaps_toggle_thinking_binding(
         self, tmp_data_dir, app_config, stub_network, monkeypatch
     ):
@@ -796,11 +857,14 @@ class TestSystemCommands:
             for title in (
                 "New chat",
                 "Edit chat parameters",
+                "Toggle thinking",
+                "Copy message",
                 "Rename chat",
                 "Clear chat",
                 "Delete chat",
                 "Export chat",
                 "Regenerate last message",
+                "Prompt history",
                 "Show logs",
             ):
                 assert title in cmds

--- a/tests/widgets/test_chat_container.py
+++ b/tests/widgets/test_chat_container.py
@@ -931,6 +931,88 @@ class TestHistoryCallback:
             assert prompt.text == "line1\nline2"
 
 
+class TestCopyMessage:
+    async def test_copies_last_message_to_clipboard(self, chat_model):
+        messages = [
+            MessageModel(chat_id=1, role="user", text="the question"),
+            MessageModel(chat_id=1, role="assistant", text="the answer"),
+        ]
+        app = _Host(chat_model, messages)
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            await container.load_messages()
+            copied: list[str] = []
+            app.copy_to_clipboard = lambda t: copied.append(t)  # ty: ignore[invalid-assignment]
+
+            container.action_copy_message()
+            await pilot.pause()
+
+            assert copied == ["the answer"]
+            assert any("copied" in n.message.lower() for n in _notifications(app))
+
+    async def test_copy_is_a_silent_noop_with_nothing_to_copy(self, chat_model):
+        """No messages, and an assistant item mounted by response_task before its
+        first delta, both copy nothing and say nothing."""
+        app = _Host(chat_model, [])
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            copied: list[str] = []
+            app.copy_to_clipboard = lambda t: copied.append(t)  # ty: ignore[invalid-assignment]
+
+            container.action_copy_message()
+            await pilot.pause()
+            assert copied == []
+            assert _notifications(app) == []
+
+            item = ChatItem()
+            item.author = "assistant"
+            await container.query_one("#messageContainer").mount(item)
+            await pilot.pause()
+
+            container.action_copy_message()
+            await pilot.pause()
+            assert copied == []
+            assert _notifications(app) == []
+
+    async def test_clicking_an_empty_message_copies_nothing(self, chat_model):
+        app = _Host(chat_model, [])
+        async with app.run_test(size=(120, 40)) as pilot:
+            container = app.query_one(ChatContainer)
+            item = ChatItem()
+            item.author = "assistant"
+            await container.query_one("#messageContainer").mount(item)
+            await pilot.pause()
+
+            copied: list[str] = []
+            app.copy_to_clipboard = lambda t: copied.append(t)  # ty: ignore[invalid-assignment]
+
+            await pilot.click(item.query_one(".response", Markdown))
+            await pilot.pause()
+            assert copied == []
+            assert _notifications(app) == []
+
+    async def test_copies_streaming_text_not_yet_in_messages(self, chat_model):
+        """``messages`` is only appended once streaming finishes, so the copy must
+        read the widget to pick up a response still in flight."""
+        messages = [MessageModel(chat_id=1, role="assistant", text="stale")]
+        app = _Host(chat_model, messages)
+        async with app.run_test() as pilot:
+            container = app.query_one(ChatContainer)
+            streaming = ChatItem()
+            streaming.author = "assistant"
+            await container.query_one("#messageContainer").mount(streaming)
+            await streaming.append_text("in flight")
+            await pilot.pause()
+
+            copied: list[str] = []
+            app.copy_to_clipboard = lambda t: copied.append(t)  # ty: ignore[invalid-assignment]
+
+            container.action_copy_message()
+            await pilot.pause()
+
+            assert copied == ["in flight"]
+
+
 class TestChatItemClickCopy:
     async def test_clicking_copies_text_to_clipboard(self, chat_model):
         app = _Host(chat_model, [])


### PR DESCRIPTION
Closes #310.

Copying a message was mouse-only, via `ChatItem.on_click`. This extracts that
into `ChatItem.copy()` and reaches it from a new `ChatContainer.action_copy_message`,
so it is available from the keyboard, remappable through the `keymap` config
block, and listed in the command palette.

- `copy.message` binding, `ctrl+o` by default. Not `ctrl+y` as "yank" would
  suggest: `TextArea.BINDINGS` claims `ctrl+y,super+y` for redo, its
  `check_action` returns `True` unconditionally, and the prompt is focused on
  mount, so a non-priority app binding on `ctrl+y` never fires. Not `ctrl+p`
  either, which Textual uses for the command palette. `ctrl+f/g/o/r` are the
  keys left once `TextArea`, `App` and oterm's own bindings are excluded, minus
  `ctrl+h` (backspace), `ctrl+j` (LF), `ctrl+s` (XOFF) and `ctrl+b` (tmux prefix).
- The action reads the last `ChatItem` widget rather than `self.messages[-1]`.
  `messages` is only appended once a response has finished streaming, so a
  keypress mid-stream would otherwise copy the previous message.
- Empty last item is treated as nothing to copy. `response_task` mounts the
  assistant item before the first delta arrives, so a keypress right as a
  response starts would otherwise put an empty string on the clipboard and
  still report success.

`test_copy_message_key_reaches_the_action_from_the_prompt` presses the key with
the prompt focused and reads the key off the binding, so moving `copy.message`
onto a key the prompt's editor claims fails the suite instead of silently
regressing.