### PR TITLE
Remember the provider used for the last created chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- New chats pre-select the provider of the last created chat. ([#298](https://github.com/ggozad/oterm/issues/298))
+
 ## [0.22.0] - 2026-07-31
 
 ### Fixed

--- a/src/oterm/app/oterm.py
+++ b/src/oterm/app/oterm.py
@@ -13,6 +13,7 @@ from oterm.app.themes.solarized_dark import solarized_dark
 from oterm.app.widgets.chat import ChatContainer
 from oterm.app.widgets.empty_state import EmptyState
 from oterm.config import appConfig
+from oterm.providers import get_available_providers
 from oterm.store.store import Store
 from oterm.tools import load_tools
 from oterm.tools.mcp.setup import teardown_mcp_servers
@@ -100,7 +101,13 @@ class OTerm(App):
     @work
     async def action_new_chat(self) -> None:
         store = await Store.get_store()
-        model_info: str | None = await self.push_screen_wait(ChatEdit())
+        last_provider = await store.get_last_provider()
+        chat_model = (
+            ChatModel(provider=last_provider)
+            if last_provider in get_available_providers()
+            else ChatModel()
+        )
+        model_info: str | None = await self.push_screen_wait(ChatEdit(chat_model))
         if not model_info:
             return
 

--- a/src/oterm/store/store.py
+++ b/src/oterm/store/store.py
@@ -193,6 +193,20 @@ class Store:
                 )
             return None
 
+    async def get_last_provider(self) -> str | None:
+        """Provider of the most recently created chat, or None when there are none."""
+        async with aiosqlite.connect(self.db_path) as connection:
+            res = await connection.execute(
+                """
+                SELECT provider
+                FROM chat
+                ORDER BY id DESC
+                LIMIT 1;
+                """
+            )
+            row = await res.fetchone()
+            return row[0] if row else None
+
     async def delete_chat(self, id: int) -> None:
         async with aiosqlite.connect(self.db_path) as connection:
             await connection.execute("PRAGMA foreign_keys = on;")

--- a/tests/app/test_oterm_app.py
+++ b/tests/app/test_oterm_app.py
@@ -2,6 +2,7 @@ import pytest
 from textual.widgets import TabbedContent, TabPane
 
 from oterm.types import ChatModel, MessageModel
+from tests._helpers import wait_until
 
 
 @pytest.fixture(autouse=True)
@@ -306,6 +307,53 @@ class TestNewChat:
 
             assert app.query_one(EmptyState).display is False
             assert app.query_one(TabbedContent).display is True
+
+    @pytest.mark.parametrize(
+        "chats,available,expected",
+        [
+            (["ollama", "anthropic"], ["ollama", "anthropic"], "anthropic"),
+            (["anthropic"], ["groq", "ollama"], "ollama"),
+        ],
+        ids=["most_recent_chat", "unavailable_falls_back"],
+    )
+    async def test_new_chat_provider_comes_from_the_last_chat(
+        self,
+        tmp_data_dir,
+        app_config,
+        stub_network,
+        store,
+        monkeypatch,
+        chats,
+        available,
+        expected,
+    ):
+        """A new chat starts on the most recently created chat's provider, unless
+        that provider is no longer available."""
+        import oterm.app.oterm as oterm_mod
+        from oterm.app.oterm import OTerm
+
+        app_config.set("splash-screen", False)
+        for provider in chats:
+            await store.save_chat(
+                ChatModel(name=provider, model="m", provider=provider)
+            )
+
+        monkeypatch.setattr(oterm_mod, "get_available_providers", lambda: available)
+
+        seen: list[str] = []
+
+        async def capture(self, screen):
+            seen.append(screen.provider)
+            return None
+
+        monkeypatch.setattr(OTerm, "push_screen_wait", capture)
+
+        app = OTerm()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.action_new_chat()
+            await wait_until(pilot, lambda: bool(seen))
+            assert seen == [expected]
 
     async def test_new_chat_cancelled_modal_noop(self, fresh_app, store, monkeypatch):
         from oterm.app.oterm import OTerm

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -71,6 +71,17 @@ async def test_get_chat_missing_returns_none(store: Store):
     assert await store.get_chat(9999) is None
 
 
+async def test_get_last_provider_returns_most_recently_created(store: Store):
+    await store.save_chat(ChatModel(name="first", model="m", provider="ollama"))
+    await store.save_chat(ChatModel(name="second", model="m", provider="anthropic"))
+
+    assert await store.get_last_provider() == "anthropic"
+
+
+async def test_get_last_provider_with_no_chats_returns_none(store: Store):
+    assert await store.get_last_provider() is None
+
+
 async def test_rename_chat(store: Store):
     chat = ChatModel(name="old", model="m")
     chat_id = await store.save_chat(chat)


### PR DESCRIPTION
Closes #298.

New chats always opened on `ollama`, so anyone working with a single
non-Ollama provider had to reselect it every time. A new chat now starts on
the provider of the most recently created chat.

The value is derived, not persisted. The `chat` table already records
`provider` for every chat, so `Store.get_last_provider()` reads the most
recent row rather than introducing a second source of truth that could go
stale. No new config key.

A provider that is no longer in `get_available_providers()` is ignored,
otherwise removing an API key would leave every new chat opening on an
unavailable provider with the existing "not currently available" warning
firing each time.

Not implemented: #298 also floats an opt-out setting and a "preferred set of
providers". Both skipped as speculative.