### PR TITLE
Rely on pydantic to determine DeepSeek thinking capability

### DIFF
--- a/src/oterm/providers/capabilities.py
+++ b/src/oterm/providers/capabilities.py
@@ -69,13 +69,8 @@ def _supports_thinking(provider: str, model: str) -> bool:
     """Per-provider reasoning/thinking support, sourced from pydantic-ai profiles.
 
     Falls back to ``False`` for providers pydantic-ai doesn't recognise (e.g.
-    ``huggingface``) and for malformed model names. DeepSeek is special-cased
-    because its profile delegates to the OpenAI profile, which doesn't know
-    about the ``-reasoner`` suffix.
+    ``huggingface``) and for malformed model names.
     """
-    if provider == "deepseek":
-        return "reasoner" in model
-
     from pydantic_ai.providers import infer_provider_class
 
     try:

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -91,8 +91,8 @@ class TestGetCapabilities:
         caps = get_capabilities("grok", "grok-vision-beta")
         assert caps.supports_vision is True
 
-    def test_deepseek_reasoner_thinking(self):
-        caps = get_capabilities("deepseek", "deepseek-reasoner")
+    def test_deepseek_thinking(self):
+        caps = get_capabilities("deepseek", "deepseek-v4-flash")
         assert caps.supports_thinking is True
 
     def test_unknown_provider_defaults(self):


### PR DESCRIPTION
The reasoner model is no longer served by DeepSeek and with it goes the need to string matching check. Now Pydantic properly determines that all V4 models have thinking capability.

Update capabilities unit test to check for DeepSeek's current V4 model.

Fixes #328