### PR TITLE
feat: add OrcaRouter as a built-in provider

### DIFF
--- a/docs/app_config.md
+++ b/docs/app_config.md
@@ -123,8 +123,11 @@ When configured, an **OpenAI Compatible** provider appears in the provider dropd
 | Grok              | `grok`            | `GROK_API_KEY`                                  |
 | Cerebras          | `cerebras`        | `CEREBRAS_API_KEY`                              |
 | Hugging Face      | `huggingface`     | `HF_TOKEN`                                      |
+| OrcaRouter        | `orcarouter`      | `ORCAROUTER_API_KEY`                            |
 
 The `openai-responses` provider routes through OpenAI's Responses API and enables image generation as a builtin tool — pick a Responses-compatible model (e.g. `gpt-5.4`) and ask for an image in the prompt. Returned images render inline in the chat; click one to save it to `$OTERM_DATA_DIR/downloads/`.
+
+[OrcaRouter](https://www.orcarouter.ai) is a gateway to 500+ models from a single OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Set `ORCAROUTER_API_KEY` to an `sk-orca-` key and pick any model from the [models catalog](https://www.orcarouter.ai/models) (e.g. `anthropic/claude-4`).
 
 For any other backend with an OpenAI-compatible API, see the [`openaiCompatible`](#openaicompatible-custom-openai-compatible-endpoints) config block above.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,7 +3,7 @@
 * intuitive and simple terminal UI, no need to run servers, frontends, just type `oterm` in your terminal.
 * supports Linux, MacOS, and Windows and most terminal emulators.
 * multiple persistent chat sessions, stored together with system prompt & parameter customizations in sqlite.
-* talks to Ollama, OpenAI, Anthropic, Google (AI / Vertex), Groq, Mistral, Cohere, AWS Bedrock, DeepSeek, Cerebras, Grok, Hugging Face, and any OpenAI-compatible endpoint — local (vLLM, LM Studio, llama.cpp, …) or hosted (OpenRouter, LiteLLM, …).
+* talks to Ollama, OpenAI, Anthropic, Google (AI / Vertex), Groq, Mistral, Cohere, AWS Bedrock, DeepSeek, Cerebras, Grok, Hugging Face, OrcaRouter, and any OpenAI-compatible endpoint — local (vLLM, LM Studio, llama.cpp, …) or hosted (OpenRouter, LiteLLM, …).
 * tools — built-in (`shell`, `date_time`, `think`), custom Python plugins via entry points, and any [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server.
 * capabilities — web search, URL fetching, persistent memory, and sandboxed file access.
 * allows for easy customization of the model's system prompt and parameters.

--- a/src/oterm/agent.py
+++ b/src/oterm/agent.py
@@ -112,6 +112,17 @@ def get_agent(
                 api_key=os.getenv(env_var) or UNRESOLVED_API_KEY,
             ),
         )
+    elif provider == "orcarouter":
+        from oterm.providers import _BUILTIN_OPENAI_COMPAT, UNRESOLVED_API_KEY
+
+        base_url, env_var = _BUILTIN_OPENAI_COMPAT["orcarouter"]
+        pydantic_model = OpenAIChatModel(
+            model_name=model,
+            provider=OpenAIProvider(
+                base_url=base_url,
+                api_key=os.getenv(env_var) or UNRESOLVED_API_KEY,
+            ),
+        )
     else:
         pydantic_model = f"{provider}:{model}"
 

--- a/src/oterm/providers/__init__.py
+++ b/src/oterm/providers/__init__.py
@@ -18,6 +18,7 @@ PROVIDER_ENV_VARS: dict[str, list[str]] = {
     "grok": ["GROK_API_KEY"],
     "cerebras": ["CEREBRAS_API_KEY"],
     "huggingface": ["HF_TOKEN"],
+    "orcarouter": ["ORCAROUTER_API_KEY"],
 }
 
 PROVIDER_NAMES: dict[str, str] = {
@@ -35,6 +36,7 @@ PROVIDER_NAMES: dict[str, str] = {
     "grok": "Grok",
     "cerebras": "Cerebras",
     "huggingface": "Hugging Face",
+    "orcarouter": "OrcaRouter",
 }
 
 
@@ -169,6 +171,7 @@ _BUILTIN_OPENAI_COMPAT: dict[str, tuple[str, str]] = {
     "deepseek": ("https://api.deepseek.com/v1", "DEEPSEEK_API_KEY"),
     "cerebras": ("https://api.cerebras.ai/v1", "CEREBRAS_API_KEY"),
     "grok": ("https://api.x.ai/v1", "GROK_API_KEY"),
+    "orcarouter": ("https://api.orcarouter.ai/v1", "ORCAROUTER_API_KEY"),
 }
 
 

--- a/src/oterm/providers/settings.py
+++ b/src/oterm/providers/settings.py
@@ -29,6 +29,7 @@ PROVIDER_SETTINGS_TYPE: dict[str, type] = {
     "bedrock": BedrockModelSettings,
     "cerebras": CerebrasModelSettings,
     "huggingface": HuggingFaceModelSettings,
+    "orcarouter": OpenAIChatModelSettings,
 }
 
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -270,6 +270,26 @@ class TestGetAgent:
         assert agent.model.client.api_key == UNRESOLVED_API_KEY
         assert agent.model.client.api_key != "sk-real"
 
+    def test_orcarouter_routes_through_orcarouter_endpoint(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-secret")
+        agent = get_agent(provider="orcarouter", model="anthropic/claude-4")
+        assert isinstance(agent.model, OpenAIChatModel)
+        assert isinstance(agent.model._provider, OpenAIProvider)
+        assert (
+            str(agent.model.client.base_url).rstrip("/")
+            == "https://api.orcarouter.ai/v1"
+        )
+        assert agent.model.client.api_key == "sk-orca-secret"
+
+    def test_orcarouter_missing_key_falls_back_to_unresolved(self, monkeypatch):
+        """A missing ORCAROUTER_API_KEY must not leak OPENAI_API_KEY to OrcaRouter."""
+        monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-real")
+        agent = get_agent(provider="orcarouter", model="anthropic/claude-4")
+        assert isinstance(agent.model, OpenAIChatModel)
+        assert agent.model.client.api_key == UNRESOLVED_API_KEY
+        assert agent.model.client.api_key != "sk-real"
+
     def test_fallthrough_provider_uses_prefix_string(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         agent = get_agent(provider="anthropic", model="claude-4")

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -259,6 +259,27 @@ class TestListModelsFromApi:
         _install_fake_module(monkeypatch, "openai", {"OpenAI": boom})
         assert _list_models_from_api("deepseek") is None
 
+    def test_builtin_compat_orcarouter(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "k")
+        items = [_FakeModelItem("anthropic/claude-4")]
+        _install_fake_module(
+            monkeypatch, "openai", {"OpenAI": lambda **kw: _FakeClient(items)}
+        )
+        assert _list_models_from_api("orcarouter") == ["anthropic/claude-4"]
+
+    def test_builtin_compat_orcarouter_no_api_key(self, monkeypatch):
+        monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+        assert _list_models_from_api("orcarouter") is None
+
+    def test_builtin_compat_orcarouter_error(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "k")
+
+        def boom(**kw):
+            raise RuntimeError("x")
+
+        _install_fake_module(monkeypatch, "openai", {"OpenAI": boom})
+        assert _list_models_from_api("orcarouter") is None
+
     def test_google(self, monkeypatch):
         class _Model:
             def __init__(self, name):


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a built-in named provider, alongside the other OpenAI-compatible builtins (`groq`, `deepseek`, `cerebras`, `grok`). OrcaRouter is a gateway to 500+ models from a single OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`) and key (`ORCAROUTER_API_KEY`, `sk-orca-...`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `src/oterm/providers/__init__.py`: registers provider id `orcarouter` in `PROVIDER_ENV_VARS`, `PROVIDER_NAMES`, and `_BUILTIN_OPENAI_COMPAT` (base URL `https://api.orcarouter.ai/v1`, env var `ORCAROUTER_API_KEY`).
- `src/oterm/providers/settings.py`: maps `orcarouter` to `OpenAIChatModelSettings` in `PROVIDER_SETTINGS_TYPE`.
- `src/oterm/agent.py`: routes `orcarouter` through `OpenAIChatModel`/`OpenAIProvider`, mirroring the existing `grok` branch.
- `tests/unit/test_agent.py`, `tests/unit/test_providers.py`: unit tests for agent wiring, missing-key fallback, and model listing.
- `docs/features.md`, `docs/app_config.md`: provider row and usage note.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how the other named OpenAI-compatible builtins (`grok`, `deepseek`, `cerebras`) are wired in this repo — the provider appears in the new-chat dropdown when `ORCAROUTER_API_KEY` is set, model listing works out of the box, and the config reference stays consistent for users.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Pick a namespaced model id such as `openai/gpt-5.5`, `anthropic/claude-opus-4.8` or `z-ai/glm-5.2`. The full catalog is at https://www.orcarouter.ai/models.

Named routers such as `orcarouter/auto` pick an upstream per request.

## Verification

- Lint/format/type: `ruff check`, `ruff format --check`, `ty check` all pass.
- Unit tests: full suite green on CI shape — the files touched here are 100% covered. Targeted run: `110 passed`.
- Live API (L3, real `sk-orca-` key through oterm's own code path):
  - `_list_models_from_api("orcarouter")` → 193 models, contains `openai/gpt-5.5`.
  - `get_agent(provider="orcarouter", model="openai/gpt-5.5")` → `OpenAIProvider` at `https://api.orcarouter.ai/v1` with the key attached.
  - `agent.run("Reply with exactly: ORCA-OK")` → content `ORCA-OK` over `/v1/chat/completions`.
