### PR TITLE
Document using oterm with llmman

### DIFF
--- a/docs/app_config.md
+++ b/docs/app_config.md
@@ -128,6 +128,18 @@ The `openai-responses` provider routes through OpenAI's Responses API and enable
 
 For any other backend with an OpenAI-compatible API, see the [`openaiCompatible`](#openaicompatible-custom-openai-compatible-endpoints) config block above.
 
+### Using with llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port `17434`. Point the `ollama` provider at it and it works as a drop-in, including model listing and capability detection:
+
+```sh
+llmman serve
+llmman pull gemma4
+OLLAMA_HOST=127.0.0.1:17434 oterm
+```
+
+Alternatively, add `http://localhost:17434/v1` as an [`openaiCompatible`](#openaicompatible-custom-openai-compatible-endpoints) endpoint (no `api_key` needed).
+
 ## Environment variables
 
 | Variable             | Default              | Purpose                                                                 |

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,7 +10,7 @@
 
 ## Using oterm
 
-`oterm` picks up providers automatically from your environment. If [Ollama](https://github.com/ollama/ollama) is running on `http://127.0.0.1:11434` it shows up out of the box; for any other hosted provider, set the relevant API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) and it appears in the provider dropdown. For other local runners (vLLM, LM Studio, llama.cpp, …) or hosted OpenAI-compatible endpoints (OpenRouter, LiteLLM, …), add an entry to the `openaiCompatible` section of `config.json`. See [Providers and API keys](app_config.md#providers-and-api-keys) and the [`openaiCompatible`](app_config.md#openaicompatible-custom-openai-compatible-endpoints) config block.
+`oterm` picks up providers automatically from your environment. If [Ollama](https://github.com/ollama/ollama) is running on `http://127.0.0.1:11434` it shows up out of the box ([llmman](https://github.com/llmmanorg/llmman) serves the same API on port `17434`; see [Using with llmman](app_config.md#using-with-llmman)); for any other hosted provider, set the relevant API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) and it appears in the provider dropdown. For other local runners (vLLM, LM Studio, llama.cpp, …) or hosted OpenAI-compatible endpoints (OpenRouter, LiteLLM, …), add an entry to the `openaiCompatible` section of `config.json`. See [Providers and API keys](app_config.md#providers-and-api-keys) and the [`openaiCompatible`](app_config.md#openaicompatible-custom-openai-compatible-endpoints) config block.
 
 To point Ollama at a non-default host or disable SSL verification, see [Environment variables](app_config.md#environment-variables).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 ## Installation
 
 !!! note
-    `oterm` works with multiple LLM providers — local and hosted. For local models, point it at [Ollama](https://github.com/ollama/ollama?tab=readme-ov-file#ollama), [vLLM](https://docs.vllm.ai/), [LM Studio](https://lmstudio.ai/), [llama.cpp](https://github.com/ggml-org/llama.cpp), or any OpenAI-compatible runner. For hosted providers (OpenAI, Anthropic, Groq, …), set the relevant API key. See [Providers and API keys](app_config.md#providers-and-api-keys) and the [`openaiCompatible`](app_config.md#openaicompatible-custom-openai-compatible-endpoints) config block.
+    `oterm` works with multiple LLM providers — local and hosted. For local models, point it at [Ollama](https://github.com/ollama/ollama?tab=readme-ov-file#ollama), [llmman](https://github.com/llmmanorg/llmman), [vLLM](https://docs.vllm.ai/), [LM Studio](https://lmstudio.ai/), [llama.cpp](https://github.com/ggml-org/llama.cpp), or any OpenAI-compatible runner. For hosted providers (OpenAI, Anthropic, Groq, …), set the relevant API key. See [Providers and API keys](app_config.md#providers-and-api-keys) and the [`openaiCompatible`](app_config.md#openaicompatible-custom-openai-compatible-endpoints) config block.
 
 === "uvx"
 


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API (plus OpenAI- and Anthropic-compatible ones) on port 17434.

- Docs only. oterm's `ollama` provider is driven by `OLLAMA_HOST` / `OLLAMA_URL`, so `OLLAMA_HOST=127.0.0.1:17434 oterm` already works as a drop-in; a separate built-in provider would duplicate the Ollama path for a different default port.
- `docs/app_config.md`: new `### Using with llmman` subsection with the three-line recipe and the `openaiCompatible` alternative.
- `docs/installation.md`, `docs/features.md`: list llmman next to Ollama alongside the other local runners, linking to the new subsection.

**Testing:** `uvx zensical build` passes and the rendered `app_config/index.html` contains the `using-with-llmman` anchor; `git diff --check` clean.

> AI-assisted, reviewed before submitting.
